### PR TITLE
Feature/control stream termination

### DIFF
--- a/src/main/java/de/telekom/horizon/pulsar/api/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/de/telekom/horizon/pulsar/api/RestResponseEntityExceptionHandler.java
@@ -5,10 +5,7 @@
 package de.telekom.horizon.pulsar.api;
 
 import de.telekom.eni.pandora.horizon.model.common.ProblemMessage;
-import de.telekom.horizon.pulsar.exception.ConnectionCutOutException;
-import de.telekom.horizon.pulsar.exception.ConnectionTimeoutException;
-import de.telekom.horizon.pulsar.exception.QueueWaitTimeoutException;
-import de.telekom.horizon.pulsar.exception.SubscriberDoesNotMatchSubscriptionException;
+import de.telekom.horizon.pulsar.exception.*;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.catalina.connector.ClientAbortException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,6 +61,7 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
      */
     @ExceptionHandler(value = {
             ConnectionCutOutException.class,
+            StreamLimitExceededException.class
     })
     @ResponseStatus(HttpStatus.OK)
     protected ResponseEntity<Object> handleCutOut(Exception e, WebRequest request) {

--- a/src/main/java/de/telekom/horizon/pulsar/api/SseController.java
+++ b/src/main/java/de/telekom/horizon/pulsar/api/SseController.java
@@ -5,6 +5,7 @@
 package de.telekom.horizon.pulsar.api;
 
 import de.telekom.horizon.pulsar.exception.SubscriberDoesNotMatchSubscriptionException;
+import de.telekom.horizon.pulsar.helper.StreamLimit;
 import de.telekom.horizon.pulsar.service.SseService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -56,10 +57,13 @@ public class SseController {
     /**
      * Retrieves SSE stream for the specified subscriptionId.
      *
-     * @param environment       The environment path variable.
-     * @param subscriptionId    The subscriptionId path variable.
+     * @param environment        The environment path variable.
+     * @param subscriptionId     The subscriptionId path variable.
      * @param includeHttpHeaders Whether to include HTTP headers in the response.
-     * @param accept            The value of the "Accept" header in the request.
+     * @param maxNumber          Whether to terminate after a certain number of consumed events.
+     * @param maxMinutes         Whether to terminate after a certain time (in minutes).
+     * @param maxBytes           Whether to terminate after a certain number of bytes consumed.
+     * @param accept             The value of the "Accept" header in the request.
      * @return A response containing a {@code ResponseBodyEmitter} for SSE streaming.
      * @throws SubscriberDoesNotMatchSubscriptionException If the subscriber does not match the specified subscription.
      */
@@ -67,6 +71,9 @@ public class SseController {
     public ResponseEntity<ResponseBodyEmitter> getSseStream(@PathVariable String environment,
                                                             @PathVariable String subscriptionId,
                                                             @RequestParam(defaultValue = "false") boolean includeHttpHeaders,
+                                                            @RequestParam(defaultValue = "0") int maxNumber,
+                                                            @RequestParam(defaultValue = "0") int maxMinutes,
+                                                            @RequestParam(defaultValue = "0") int maxBytes,
                                                             @RequestHeader(value = HttpHeaders.ACCEPT, required = false) String accept) throws SubscriberDoesNotMatchSubscriptionException {
 
         sseService.validateSubscriberIdForSubscription(environment, subscriptionId);
@@ -76,7 +83,7 @@ public class SseController {
             accept = APPLICATION_STREAM_JSON_VALUE;
         }
 
-        var responseContainer = sseService.startEmittingEvents(environment, subscriptionId, accept, includeHttpHeaders);
+        var responseContainer = sseService.startEmittingEvents(environment, subscriptionId, accept, includeHttpHeaders, StreamLimit.of(maxNumber, maxMinutes, maxBytes));
 
         var responseHeaders = new HttpHeaders();
         responseHeaders.add(HttpHeaders.CONTENT_TYPE, accept);

--- a/src/main/java/de/telekom/horizon/pulsar/api/SseController.java
+++ b/src/main/java/de/telekom/horizon/pulsar/api/SseController.java
@@ -86,4 +86,20 @@ public class SseController {
 
         return new ResponseEntity<>(responseContainer.getEmitter(), responseHeaders, HttpStatus.OK);
     }
+
+    /**
+     * Stops an active SSE stream for the specified subscriptionId.
+     *
+     * @param environment       The environment path variable.
+     * @param subscriptionId    The subscriptionId path variable.
+     * @throws SubscriberDoesNotMatchSubscriptionException If the subscriber does not match the specified subscription.
+     */
+    @PostMapping(value = "/sse/{subscriptionId}/terminate", produces = {MediaType.ALL_VALUE, APPLICATION_STREAM_JSON_VALUE, MediaType.TEXT_EVENT_STREAM_VALUE})
+    public ResponseEntity<Void> terminateSseStream(@PathVariable String environment, @PathVariable String subscriptionId) throws SubscriberDoesNotMatchSubscriptionException {
+
+        sseService.validateSubscriberIdForSubscription(environment, subscriptionId);
+        sseService.stopEmittingEvents(subscriptionId);
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
 }

--- a/src/main/java/de/telekom/horizon/pulsar/exception/StreamLimitExceededException.java
+++ b/src/main/java/de/telekom/horizon/pulsar/exception/StreamLimitExceededException.java
@@ -1,0 +1,11 @@
+// Copyright 2024 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package de.telekom.horizon.pulsar.exception;
+
+public class StreamLimitExceededException extends HorizonPulsarException {
+    public StreamLimitExceededException() {
+        super();
+    }
+}

--- a/src/main/java/de/telekom/horizon/pulsar/helper/EventMessageContext.java
+++ b/src/main/java/de/telekom/horizon/pulsar/helper/EventMessageContext.java
@@ -17,7 +17,7 @@ import java.util.Optional;
  * Context class representing the context of an event message in a subscription.
  *
  * This class encapsulates information related to a subscription event message, including
- * whether to include HTTP headers, and optional tracing components such as a span and span in scope.
+ * whether to include HTTP headers or stream limits, and optional tracing components such as a span and span in scope.
  * It provides a method to finish the span and span in scope if they are present.
  */
 
@@ -28,6 +28,9 @@ public class EventMessageContext {
     private SubscriptionEventMessage subscriptionEventMessage;
     @Getter
     private Boolean includeHttpHeaders;
+    @Getter
+    private StreamLimit streamLimit;
+
     private Span span;
     private Tracer.SpanInScope spanInScope;
     public void finishSpan() {

--- a/src/main/java/de/telekom/horizon/pulsar/helper/StreamLimit.java
+++ b/src/main/java/de/telekom/horizon/pulsar/helper/StreamLimit.java
@@ -1,3 +1,7 @@
+// Copyright 2024 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package de.telekom.horizon.pulsar.helper;
 
 

--- a/src/main/java/de/telekom/horizon/pulsar/helper/StreamLimit.java
+++ b/src/main/java/de/telekom/horizon/pulsar/helper/StreamLimit.java
@@ -1,0 +1,29 @@
+package de.telekom.horizon.pulsar.helper;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Class that contains any streaming limits provided by the customer.
+ *
+ * This class encapsulates all possible streaming limits that have been provided by the customer when
+ * requesting a new stream. The streaming limits will ensure that a active stream terminates early on when exceeded.
+ * Currently, a customer can specify that the stream should terminate when a specific number of events have been consumed
+ * or after a certain time (in minutes) or after exceeding a certain number of bytes which have been consumed.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class StreamLimit {
+    private int maxNumber;
+    private int maxMinutes;
+    private long maxBytes;
+
+    public static StreamLimit of(int maxNumber, int maxMinutes, int maxBytes) {
+        return new StreamLimit(maxNumber, maxMinutes, maxBytes);
+    }
+}

--- a/src/main/java/de/telekom/horizon/pulsar/service/SseService.java
+++ b/src/main/java/de/telekom/horizon/pulsar/service/SseService.java
@@ -4,7 +4,6 @@
 
 package de.telekom.horizon.pulsar.service;
 
-import de.telekom.eni.pandora.horizon.cache.service.DeDuplicationService;
 import de.telekom.horizon.pulsar.cache.SubscriberCache;
 import de.telekom.horizon.pulsar.config.PulsarConfig;
 import de.telekom.horizon.pulsar.exception.SubscriberDoesNotMatchSubscriptionException;
@@ -42,14 +41,12 @@ public class SseService {
      * @param sseTaskFactory                The {@link SseTaskFactory} for creating Server-Sent Event tasks.
      * @param subscriberCache               The {@link SubscriberCache} for caching subscriber information.
      * @param pulsarConfig                  The {@link PulsarConfig} for Pulsar-related configuration.
-     * @param deDuplicationService          The {@link DeDuplicationService} for handling message deduplication.
      */
     @Autowired
     public SseService(TokenService tokenService,
                       SseTaskFactory sseTaskFactory,
                       SubscriberCache subscriberCache,
-                      PulsarConfig pulsarConfig,
-                      DeDuplicationService deDuplicationService) {
+                      PulsarConfig pulsarConfig) {
 
         this.tokenService = tokenService;
         this.sseTaskFactory = sseTaskFactory;
@@ -108,4 +105,12 @@ public class SseService {
         return responseContainer;
     }
 
+    /**
+     * Stops emitting events for an existing active stream.
+     *
+     * @param subscriptionId   The ID of the subscription for which events are being emitted.
+     */
+    public void stopEmittingEvents(String subscriptionId) {
+        sseTaskFactory.getConnectionCache().removeConnectionForSubscription(subscriptionId);
+    }
 }

--- a/src/main/java/de/telekom/horizon/pulsar/service/SseService.java
+++ b/src/main/java/de/telekom/horizon/pulsar/service/SseService.java
@@ -8,6 +8,7 @@ import de.telekom.horizon.pulsar.cache.SubscriberCache;
 import de.telekom.horizon.pulsar.config.PulsarConfig;
 import de.telekom.horizon.pulsar.exception.SubscriberDoesNotMatchSubscriptionException;
 import de.telekom.horizon.pulsar.helper.SseTaskStateContainer;
+import de.telekom.horizon.pulsar.helper.StreamLimit;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.logging.log4j.util.Strings;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -95,10 +96,10 @@ public class SseService {
      * @param includeHttpHeaders A boolean flag indicating whether to include HTTP headers in the emitted events.
      * @return The {@link SseTaskStateContainer} representing the state of the emitted events.
      */
-    public SseTaskStateContainer startEmittingEvents(String environment, String subscriptionId, String contentType, boolean includeHttpHeaders) {
+    public SseTaskStateContainer startEmittingEvents(String environment, String subscriptionId, String contentType, boolean includeHttpHeaders, StreamLimit streamLimit) {
         var responseContainer = new SseTaskStateContainer();
 
-        taskExecutor.submit(sseTaskFactory.createNew(environment, subscriptionId, contentType, responseContainer, includeHttpHeaders));
+        taskExecutor.submit(sseTaskFactory.createNew(environment, subscriptionId, contentType, responseContainer, includeHttpHeaders, streamLimit));
 
         responseContainer.setReady(pulsarConfig.getSseTimeout());
 

--- a/src/main/java/de/telekom/horizon/pulsar/service/SseTask.java
+++ b/src/main/java/de/telekom/horizon/pulsar/service/SseTask.java
@@ -182,9 +182,9 @@ public class SseTask implements Runnable {
 
         final StreamLimit streamLimit = context.getStreamLimit();
         if (streamLimit != null) {
-            final boolean maxNumberExceeded = streamLimit.getMaxNumber() > 0 && numberConsumed > streamLimit.getMaxNumber();
+            final boolean maxNumberExceeded = streamLimit.getMaxNumber() > 0 && numberConsumed >= streamLimit.getMaxNumber();
             final boolean maxMinutesExceeded = streamLimit.getMaxMinutes() > 0 && startTime.plus(streamLimit.getMaxMinutes(), ChronoUnit.MINUTES).isBefore(Instant.now());
-            final boolean maxBytesExceeded = streamLimit.getMaxBytes() > 0 && bytesConsumed > streamLimit.getMaxBytes();
+            final boolean maxBytesExceeded = streamLimit.getMaxBytes() > 0 && bytesConsumed >= streamLimit.getMaxBytes();
 
             if (maxNumberExceeded || maxMinutesExceeded || maxBytesExceeded) {
                 sseTaskStateContainer.getEmitter().completeWithError(new StreamLimitExceededException());

--- a/src/main/java/de/telekom/horizon/pulsar/service/SseTaskFactory.java
+++ b/src/main/java/de/telekom/horizon/pulsar/service/SseTaskFactory.java
@@ -12,6 +12,7 @@ import de.telekom.horizon.pulsar.cache.ConnectionCache;
 import de.telekom.horizon.pulsar.cache.ConnectionGaugeCache;
 import de.telekom.horizon.pulsar.config.PulsarConfig;
 import de.telekom.horizon.pulsar.helper.SseTaskStateContainer;
+import de.telekom.horizon.pulsar.helper.StreamLimit;
 import de.telekom.horizon.pulsar.utils.KafkaPicker;
 import lombok.Getter;
 import org.springframework.stereotype.Component;
@@ -75,12 +76,13 @@ public class SseTaskFactory {
      * @param environment               The environment associated with the subscription.
      * @param subscriptionId            The ID of the subscription for which the task is created.
      * @param contentType               The content type for the SSE task.
-     * @param sseTaskStateContainer     The {@link SseTaskStateContainer} representing the state of the SSE task.
+     * @param sseTaskStateContainer     The {@link SseTaskStateContainer} represents the state of the SSE task.
      * @param includeHttpHeaders        A boolean flag indicating whether to include HTTP headers in the SSE task.
+     * @param streamLimit               The {@link StreamLimit} represents any customer specific conditions for terminating the stream early.
      * @return The newly created {@link SseTask}.
      */
-    public SseTask createNew(String environment, String subscriptionId, String contentType, SseTaskStateContainer sseTaskStateContainer, boolean includeHttpHeaders) {
-        var eventMessageSupplier = new EventMessageSupplier(subscriptionId, this, includeHttpHeaders);
+    public SseTask createNew(String environment, String subscriptionId, String contentType, SseTaskStateContainer sseTaskStateContainer, boolean includeHttpHeaders, StreamLimit streamLimit) {
+        var eventMessageSupplier = new EventMessageSupplier(subscriptionId, this, includeHttpHeaders, streamLimit);
         var connection = connectionGaugeCache.getOrCreateGaugeForSubscription(environment, subscriptionId);
 
         var task = new SseTask(sseTaskStateContainer, eventMessageSupplier, connection, this);

--- a/src/test/java/de/telekom/horizon/pulsar/api/SseControllerSecurityEnabledTest.java
+++ b/src/test/java/de/telekom/horizon/pulsar/api/SseControllerSecurityEnabledTest.java
@@ -6,6 +6,7 @@ package de.telekom.horizon.pulsar.api;
 
 import de.telekom.horizon.pulsar.cache.SubscriberCache;
 import de.telekom.horizon.pulsar.exception.SubscriberDoesNotMatchSubscriptionException;
+import de.telekom.horizon.pulsar.helper.StreamLimit;
 import de.telekom.horizon.pulsar.service.SseService;
 import de.telekom.horizon.pulsar.utils.AbstractIntegrationTest;
 import de.telekom.horizon.pulsar.utils.MongoTestServerConfiguration;
@@ -87,7 +88,7 @@ class SseControllerSecurityEnabledTest extends AbstractIntegrationTest {
                 .andExpect(status().isOk());
 
         verify(sseService, times(1)).validateSubscriberIdForSubscription(eq(env), eq(subscriptionId));
-        verify(sseService, times(1)).startEmittingEvents(eq(env), eq(subscriptionId), any(String.class), eq(true));
+        verify(sseService, times(1)).startEmittingEvents(eq(env), eq(subscriptionId), any(String.class), eq(true), any(StreamLimit.class));
     }
 
     private Jwt getJwt(String subscriberId) {

--- a/src/test/java/de/telekom/horizon/pulsar/service/EventMessageSupplierTest.java
+++ b/src/test/java/de/telekom/horizon/pulsar/service/EventMessageSupplierTest.java
@@ -10,6 +10,7 @@ import de.telekom.eni.pandora.horizon.kafka.event.EventWriter;
 import de.telekom.eni.pandora.horizon.model.event.DeliveryType;
 import de.telekom.eni.pandora.horizon.model.event.Status;
 import de.telekom.eni.pandora.horizon.model.event.StatusMessage;
+import de.telekom.horizon.pulsar.helper.StreamLimit;
 import de.telekom.horizon.pulsar.testutils.MockHelper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -43,7 +44,7 @@ class EventMessageSupplierTest {
     void setupEventMessageSupplierTest() {
         MockHelper.init();
 
-        eventMessageSupplier = new EventMessageSupplier(MockHelper.TEST_SUBSCRIPTION_ID, MockHelper.sseTaskFactory, false);
+        eventMessageSupplier = new EventMessageSupplier(MockHelper.TEST_SUBSCRIPTION_ID, MockHelper.sseTaskFactory, false, new StreamLimit());
     }
 
     @ParameterizedTest

--- a/src/test/java/de/telekom/horizon/pulsar/service/SseServiceTest.java
+++ b/src/test/java/de/telekom/horizon/pulsar/service/SseServiceTest.java
@@ -11,6 +11,7 @@ import com.hazelcast.topic.ITopic;
 import de.telekom.horizon.pulsar.cache.ConnectionCache;
 import de.telekom.horizon.pulsar.exception.SubscriberDoesNotMatchSubscriptionException;
 import de.telekom.horizon.pulsar.helper.SseTaskStateContainer;
+import de.telekom.horizon.pulsar.helper.StreamLimit;
 import de.telekom.horizon.pulsar.testutils.MockHelper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -121,7 +122,7 @@ class SseServiceTest {
         var connectionCacheSpy = Mockito.spy(connectionCache);
 
         when(sseTaskFactoryMock.getConnectionCache()).thenReturn(connectionCacheSpy);
-        when(sseTaskFactoryMock.createNew(eq(MockHelper.TEST_ENVIRONMENT), eq(MockHelper.TEST_SUBSCRIPTION_ID), eq(MockHelper.TEST_CONTENT_TYPE), sseTaskStateContainerCaptor.capture(), eq(false))).thenReturn(sseTaskSpy);
+        when(sseTaskFactoryMock.createNew(eq(MockHelper.TEST_ENVIRONMENT), eq(MockHelper.TEST_SUBSCRIPTION_ID), eq(MockHelper.TEST_CONTENT_TYPE), sseTaskStateContainerCaptor.capture(), eq(false), any(StreamLimit.class))).thenReturn(sseTaskSpy);
 
         // The mocked task should trigger the termination condition of SseTaskStateContainer.setReady(long timeout) immediately
         // otherwise startEmittingEvents() would run until the timeout is reached, since setReady() is not called asynchronously
@@ -146,7 +147,7 @@ class SseServiceTest {
         }).start();
 
         // PUBLIC METHOD WE WANT TO TEST
-        var responseContainer = sseService.startEmittingEvents(MockHelper.TEST_ENVIRONMENT, MockHelper.TEST_SUBSCRIPTION_ID, MockHelper.TEST_CONTENT_TYPE, false);
+        var responseContainer = sseService.startEmittingEvents(MockHelper.TEST_ENVIRONMENT, MockHelper.TEST_SUBSCRIPTION_ID, MockHelper.TEST_CONTENT_TYPE, false, new StreamLimit());
 
         latch.countDown();
 

--- a/src/test/java/de/telekom/horizon/pulsar/service/SseServiceTest.java
+++ b/src/test/java/de/telekom/horizon/pulsar/service/SseServiceTest.java
@@ -4,6 +4,11 @@
 
 package de.telekom.horizon.pulsar.service;
 
+import com.hazelcast.cluster.Cluster;
+import com.hazelcast.cluster.Member;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.topic.ITopic;
+import de.telekom.horizon.pulsar.cache.ConnectionCache;
 import de.telekom.horizon.pulsar.exception.SubscriberDoesNotMatchSubscriptionException;
 import de.telekom.horizon.pulsar.helper.SseTaskStateContainer;
 import de.telekom.horizon.pulsar.testutils.MockHelper;
@@ -18,6 +23,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -38,7 +45,7 @@ class SseServiceTest {
     void setupSseServiceTest() {
         MockHelper.init();
 
-        sseService = spy(new SseService(MockHelper.tokenService, sseTaskFactoryMock, MockHelper.subscriberCache, MockHelper.pulsarConfig, MockHelper.deDuplicationService));
+        sseService = spy(new SseService(MockHelper.tokenService, sseTaskFactoryMock, MockHelper.subscriberCache, MockHelper.pulsarConfig));
     }
 
     @Test
@@ -88,10 +95,33 @@ class SseServiceTest {
         verify(taskExecutorSpy).setQueueCapacity(MockHelper.pulsarConfig.getQueueCapacity());
         verify(taskExecutorSpy).afterPropertiesSet();
 
-        // We are mocking the actual task here
-        var sseTaskMock = Mockito.mock(SseTask.class);
+        var sseTask = new SseTask(Mockito.mock(SseTaskStateContainer.class), Mockito.mock(EventMessageSupplier.class), MockHelper.openConnectionGaugeValue, sseTaskFactoryMock);
 
-        when(sseTaskFactoryMock.createNew(eq(MockHelper.TEST_ENVIRONMENT), eq(MockHelper.TEST_SUBSCRIPTION_ID), eq(MockHelper.TEST_CONTENT_TYPE), sseTaskStateContainerCaptor.capture(), eq(false))).thenReturn(sseTaskMock);
+        // We are spying on the actual task here
+        var sseTaskSpy= Mockito.spy(sseTask);
+
+        var hazelcastInstanceMock = Mockito.mock(HazelcastInstance.class);
+
+        var cacheClusterMock = Mockito.mock(Cluster.class);
+        var cacheMemberMock = Mockito.mock(Member.class);
+
+        when(hazelcastInstanceMock.getCluster()).thenReturn(cacheClusterMock);
+        when(cacheClusterMock.getLocalMember()).thenReturn(cacheMemberMock);
+        when(cacheMemberMock.getUuid()).thenReturn(UUID.fromString("477bf3c9-ef1f-41de-9574-419a2ab61131"));
+
+        var cacheWorkers = Mockito.mock(ITopic.class);
+        when(hazelcastInstanceMock.getTopic("workers")).thenReturn(cacheWorkers);
+
+        var connectionCache = new ConnectionCache(hazelcastInstanceMock);
+
+        var map = new ConcurrentHashMap<>();
+        map.put(MockHelper.TEST_SUBSCRIPTION_ID, sseTaskSpy);
+        ReflectionTestUtils.setField(connectionCache, "map", map, ConcurrentHashMap.class);
+
+        var connectionCacheSpy = Mockito.spy(connectionCache);
+
+        when(sseTaskFactoryMock.getConnectionCache()).thenReturn(connectionCacheSpy);
+        when(sseTaskFactoryMock.createNew(eq(MockHelper.TEST_ENVIRONMENT), eq(MockHelper.TEST_SUBSCRIPTION_ID), eq(MockHelper.TEST_CONTENT_TYPE), sseTaskStateContainerCaptor.capture(), eq(false))).thenReturn(sseTaskSpy);
 
         // The mocked task should trigger the termination condition of SseTaskStateContainer.setReady(long timeout) immediately
         // otherwise startEmittingEvents() would run until the timeout is reached, since setReady() is not called asynchronously
@@ -121,8 +151,12 @@ class SseServiceTest {
         latch.countDown();
 
         assertNotNull(responseContainer);
+        verify(taskExecutorSpy).submit(sseTaskSpy);
 
-        verify(taskExecutorSpy).submit(sseTaskMock);
+        sseService.stopEmittingEvents(MockHelper.TEST_SUBSCRIPTION_ID);
+
+        verify(sseTaskSpy).terminate();
+        verify(connectionCacheSpy).removeConnectionForSubscription(MockHelper.TEST_SUBSCRIPTION_ID);
     }
 }
 

--- a/src/test/java/de/telekom/horizon/pulsar/service/SseTaskFactoryTest.java
+++ b/src/test/java/de/telekom/horizon/pulsar/service/SseTaskFactoryTest.java
@@ -10,6 +10,7 @@ import de.telekom.eni.pandora.horizon.kubernetes.resource.Subscription;
 import de.telekom.eni.pandora.horizon.kubernetes.resource.SubscriptionResource;
 import de.telekom.eni.pandora.horizon.kubernetes.resource.SubscriptionResourceSpec;
 import de.telekom.horizon.pulsar.helper.SseTaskStateContainer;
+import de.telekom.horizon.pulsar.helper.StreamLimit;
 import de.telekom.horizon.pulsar.testutils.MockHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -62,7 +63,7 @@ class SseTaskFactoryTest {
         when(MockHelper.connectionGaugeCache.getOrCreateGaugeForSubscription(MockHelper.TEST_ENVIRONMENT, MockHelper.TEST_SUBSCRIPTION_ID)).thenReturn(new AtomicInteger(1));
 
         // PUBLIC METHOD WE WANT TO TEST
-        var task = sseTaskFactorySpy.createNew(MockHelper.TEST_ENVIRONMENT, MockHelper.TEST_SUBSCRIPTION_ID, MockHelper.TEST_CONTENT_TYPE, sseTaskStateContainer, false);
+        var task = sseTaskFactorySpy.createNew(MockHelper.TEST_ENVIRONMENT, MockHelper.TEST_SUBSCRIPTION_ID, MockHelper.TEST_CONTENT_TYPE, sseTaskStateContainer, false, new StreamLimit());
         assertNotNull(task);
 
         // Let's verify that connectionGaugeCache.getOrCreateGaugeForSubscription(String environment, String subscriptionId) is called

--- a/src/test/java/de/telekom/horizon/pulsar/service/SseTaskTest.java
+++ b/src/test/java/de/telekom/horizon/pulsar/service/SseTaskTest.java
@@ -13,6 +13,7 @@ import de.telekom.eni.pandora.horizon.model.event.*;
 import de.telekom.eni.pandora.horizon.tracing.HorizonTracer;
 import de.telekom.horizon.pulsar.exception.ConnectionCutOutException;
 import de.telekom.horizon.pulsar.exception.ConnectionTimeoutException;
+import de.telekom.horizon.pulsar.exception.StreamLimitExceededException;
 import de.telekom.horizon.pulsar.helper.EventMessageContext;
 import de.telekom.horizon.pulsar.helper.SseTaskStateContainer;
 import de.telekom.horizon.pulsar.helper.StreamLimit;
@@ -31,6 +32,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyEmitter
 
 import java.io.IOException;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
@@ -98,7 +100,10 @@ class SseTaskTest {
         var emitterMock = mock(ResponseBodyEmitter.class);
         when(sseTaskStateContainerMock.getEmitter()).thenReturn(emitterMock);
         // We mock the EventMessageSupplier since it's tested in a separate test
-        when(eventMessageSupplierMock.get()).thenAnswer(i -> new EventMessageContext(itemQueue.poll(), false, new StreamLimit(), Mockito.mock(Span.class), Mockito.mock(Tracer.SpanInScope.class)));
+        when(eventMessageSupplierMock.get()).thenAnswer(i -> {
+            await().pollDelay(10, TimeUnit.MICROSECONDS).untilTrue(new AtomicBoolean(true));
+            return new EventMessageContext(itemQueue.poll(), false, new StreamLimit(), Mockito.mock(Span.class), Mockito.mock(Tracer.SpanInScope.class));
+        });
         when(eventMessageSupplierMock.getSubscriptionId()).thenReturn(MockHelper.TEST_SUBSCRIPTION_ID);
         // The following checks that we track a DELIVERED event with the de-duplication service
         // which is done in the callback of the eventwriter
@@ -147,7 +152,7 @@ class SseTaskTest {
     }
 
     @Test
-    void testTerminateConnection() throws InterruptedException, JsonProcessingException {
+    void testTerminateConnection() throws InterruptedException, IOException {
         // We check whether an EventWriter has been created successfully
         // since it is not accessible, we use ReflectionTestUtils.
         // We then overwrite it with a mock, so that we can do checks on it
@@ -177,9 +182,14 @@ class SseTaskTest {
             latch.countDown();
         }).start();
 
+        var streamLimit = new StreamLimit(); // default values
+
         // We mock the EventMessageSupplier and let the mock always answer with a new event message to simulate
         // an endless stream
-        when(eventMessageSupplierMock.get()).thenAnswer(i -> new EventMessageContext(MockHelper.createSubscriptionEventMessageForTesting(DeliveryType.SERVER_SENT_EVENT, false), false, new StreamLimit(), Mockito.mock(Span.class), Mockito.mock(Tracer.SpanInScope.class)));
+        when(eventMessageSupplierMock.get()).thenAnswer(i -> {
+            await().pollDelay(10, TimeUnit.MICROSECONDS).untilTrue(new AtomicBoolean(true));
+            return new EventMessageContext(MockHelper.createSubscriptionEventMessageForTesting(DeliveryType.SERVER_SENT_EVENT, false), false, streamLimit, Mockito.mock(Span.class), Mockito.mock(Tracer.SpanInScope.class));
+        });
         when(eventMessageSupplierMock.getSubscriptionId()).thenReturn(MockHelper.TEST_SUBSCRIPTION_ID);
         // The following checks that we track a DELIVERED event with the de-duplication service
         // which is done in the callback of the eventwriter
@@ -192,10 +202,164 @@ class SseTaskTest {
         var reachedZero = latch.await(10000, TimeUnit.MILLISECONDS);
         assertTrue(reachedZero);
 
-        // Verify that cut out happened
-        verify(emitterMock, times(1)).completeWithError(any(ConnectionCutOutException.class));
+        verify(emitterMock, atLeast(1)).send(anyString());
+
         // Verify that ResponseBodyEmitter finishes with a ConnectionCutOutException
         verify(emitterMock, times(1)).completeWithError(any(ConnectionCutOutException.class));
+        // Verify that emitter has completed
+        verify(emitterMock, times(1)).onCompletion(any());
+        // Verify that metrics for a closed connection are handled
+        verify(MockHelper.openConnectionGaugeValue, times(1)).getAndSet(0);
+    }
+
+    @Test
+    void testTerminateConnectionThroughMaxNumberStreamLimit() throws IOException {
+        // We check whether an EventWriter has been created successfully
+        // since it is not accessible, we use ReflectionTestUtils.
+        // We then overwrite it with a mock, so that we can do checks on it
+        var eventWriter = (EventWriter) ReflectionTestUtils.getField(sseTaskSpy,"eventWriter");
+        assertNotNull(eventWriter);
+        var eventWriterMock = mock(EventWriter.class);
+        ReflectionTestUtils.setField(sseTaskSpy,"eventWriter", eventWriterMock);
+
+        // We assume the task has not been canceled
+        when(sseTaskStateContainerMock.getCanceled()).thenReturn(new AtomicBoolean(false));
+        // We assume the task is not running in the beginning
+        var taskRunningSpy = spy(new AtomicBoolean(false));
+        when(sseTaskStateContainerMock.getRunning()).thenReturn(taskRunningSpy);
+
+        // Mock the ResponseBodyEmitter so that we can verify data is actually sent
+        var emitterMock = mock(ResponseBodyEmitter.class);
+        when(sseTaskStateContainerMock.getEmitter()).thenReturn(emitterMock);
+
+        var maxNumberLimit = 5;
+
+        var streamLimit = StreamLimit.of(maxNumberLimit, 0, 0);
+
+        // We mock the EventMessageSupplier and let the mock always answer with a new event message to simulate
+        // an endless stream
+        when(eventMessageSupplierMock.get()).thenAnswer(i -> {
+            await().pollDelay(10, TimeUnit.MICROSECONDS).untilTrue(new AtomicBoolean(true));
+            return new EventMessageContext(MockHelper.createSubscriptionEventMessageForTesting(DeliveryType.SERVER_SENT_EVENT, false), false, streamLimit, Mockito.mock(Span.class), Mockito.mock(Tracer.SpanInScope.class));
+        });
+        when(eventMessageSupplierMock.getSubscriptionId()).thenReturn(MockHelper.TEST_SUBSCRIPTION_ID);
+        // The following checks that we track a DELIVERED event with the de-duplication service
+        // which is done in the callback of the eventwriter
+        SendResult<String, String> sendResult = mock(SendResult.class);
+        var succeededFuture = CompletableFuture.completedFuture(sendResult);
+        when(eventWriterMock.send(anyString(), notNull(), any())).thenReturn(succeededFuture);
+
+        sseTaskSpy.run();
+
+        verify(emitterMock, times(maxNumberLimit)).send(anyString());
+
+        // Verify that ResponseBodyEmitter finishes with a ConnectionCutOutException
+        verify(emitterMock, times(1)).completeWithError(any(StreamLimitExceededException.class));
+        // Verify that emitter has completed
+        verify(emitterMock, times(1)).onCompletion(any());
+        // Verify that metrics for a closed connection are handled
+        verify(MockHelper.openConnectionGaugeValue, times(1)).getAndSet(0);
+    }
+
+    @Test
+    void testTerminateConnectionThroughMaxByteStreamLimit() throws IOException {
+        // We check whether an EventWriter has been created successfully
+        // since it is not accessible, we use ReflectionTestUtils.
+        // We then overwrite it with a mock, so that we can do checks on it
+        var eventWriter = (EventWriter) ReflectionTestUtils.getField(sseTaskSpy,"eventWriter");
+        assertNotNull(eventWriter);
+        var eventWriterMock = mock(EventWriter.class);
+        ReflectionTestUtils.setField(sseTaskSpy,"eventWriter", eventWriterMock);
+
+        // We assume the task has not been canceled
+        when(sseTaskStateContainerMock.getCanceled()).thenReturn(new AtomicBoolean(false));
+        // We assume the task is not running in the beginning
+        var taskRunningSpy = spy(new AtomicBoolean(false));
+        when(sseTaskStateContainerMock.getRunning()).thenReturn(taskRunningSpy);
+
+        // Mock the ResponseBodyEmitter so that we can verify data is actually sent
+        var emitterMock = mock(ResponseBodyEmitter.class);
+        when(sseTaskStateContainerMock.getEmitter()).thenReturn(emitterMock);
+
+        var maxBytesLimit = 2000;
+
+        var streamLimit = StreamLimit.of(0, 0, maxBytesLimit);
+
+        // We mock the EventMessageSupplier and let the mock always answer with a new event message to simulate
+        // an endless stream
+        when(eventMessageSupplierMock.get()).thenAnswer(i -> {
+            await().pollDelay(10, TimeUnit.MICROSECONDS).untilTrue(new AtomicBoolean(true));
+            return new EventMessageContext(MockHelper.createSubscriptionEventMessageForTesting(DeliveryType.SERVER_SENT_EVENT, false), false, streamLimit, Mockito.mock(Span.class), Mockito.mock(Tracer.SpanInScope.class));
+        });
+        when(eventMessageSupplierMock.getSubscriptionId()).thenReturn(MockHelper.TEST_SUBSCRIPTION_ID);
+        // The following checks that we track a DELIVERED event with the de-duplication service
+        // which is done in the callback of the eventwriter
+        SendResult<String, String> sendResult = mock(SendResult.class);
+        var succeededFuture = CompletableFuture.completedFuture(sendResult);
+        when(eventWriterMock.send(anyString(), notNull(), any())).thenReturn(succeededFuture);
+
+        sseTaskSpy.run();
+
+        ArgumentCaptor<String> jsonCaptor = ArgumentCaptor.forClass(String.class);
+
+        verify(emitterMock, atLeast(1)).send(jsonCaptor.capture());
+
+        var bytesSum = jsonCaptor.getAllValues().stream().mapToInt(x -> x.getBytes().length).sum();
+
+        assertTrue(bytesSum >= maxBytesLimit);
+
+        // Verify that ResponseBodyEmitter finishes with a ConnectionCutOutException
+        verify(emitterMock, times(1)).completeWithError(any(StreamLimitExceededException.class));
+        // Verify that emitter has completed
+        verify(emitterMock, times(1)).onCompletion(any());
+        // Verify that metrics for a closed connection are handled
+        verify(MockHelper.openConnectionGaugeValue, times(1)).getAndSet(0);
+    }
+
+    @Test
+    void testTerminateConnectionThroughMaxMinutesStreamLimit() throws IOException {
+        // We check whether an EventWriter has been created successfully
+        // since it is not accessible, we use ReflectionTestUtils.
+        // We then overwrite it with a mock, so that we can do checks on it
+        var eventWriter = (EventWriter) ReflectionTestUtils.getField(sseTaskSpy,"eventWriter");
+        assertNotNull(eventWriter);
+        var eventWriterMock = mock(EventWriter.class);
+        ReflectionTestUtils.setField(sseTaskSpy,"eventWriter", eventWriterMock);
+
+        // We assume the task has not been canceled
+        when(sseTaskStateContainerMock.getCanceled()).thenReturn(new AtomicBoolean(false));
+        // We assume the task is not running in the beginning
+        var taskRunningSpy = spy(new AtomicBoolean(false));
+        when(sseTaskStateContainerMock.getRunning()).thenReturn(taskRunningSpy);
+
+        // Mock the ResponseBodyEmitter so that we can verify data is actually sent
+        var emitterMock = mock(ResponseBodyEmitter.class);
+        when(sseTaskStateContainerMock.getEmitter()).thenReturn(emitterMock);
+
+        var maxMinutes = 1;
+
+        var streamLimit = StreamLimit.of(0, maxMinutes, 0);
+
+        // We mock the EventMessageSupplier and let the mock always answer with a new event message to simulate
+        // an endless stream
+        when(eventMessageSupplierMock.get()).thenAnswer(i -> {
+            await().pollDelay(10, TimeUnit.MICROSECONDS).untilTrue(new AtomicBoolean(true));
+
+            return new EventMessageContext(MockHelper.createSubscriptionEventMessageForTesting(DeliveryType.SERVER_SENT_EVENT, false), false, streamLimit, Mockito.mock(Span.class), Mockito.mock(Tracer.SpanInScope.class));
+        });
+        when(eventMessageSupplierMock.getSubscriptionId()).thenReturn(MockHelper.TEST_SUBSCRIPTION_ID);
+        // The following checks that we track a DELIVERED event with the de-duplication service
+        // which is done in the callback of the eventwriter
+        SendResult<String, String> sendResult = mock(SendResult.class);
+        var succeededFuture = CompletableFuture.completedFuture(sendResult);
+        when(eventWriterMock.send(anyString(), notNull(), any())).thenReturn(succeededFuture);
+
+        sseTaskSpy.run();
+
+        assertEquals(maxMinutes, ChronoUnit.MINUTES.between(sseTaskSpy.getStartTime(), sseTaskSpy.getStopTime()));
+
+        // Verify that ResponseBodyEmitter finishes with a ConnectionCutOutException
+        verify(emitterMock, times(1)).completeWithError(any(StreamLimitExceededException.class));
         // Verify that emitter has completed
         verify(emitterMock, times(1)).onCompletion(any());
         // Verify that metrics for a closed connection are handled
@@ -232,7 +396,10 @@ class SseTaskTest {
         var emitterMock = mock(ResponseBodyEmitter.class);
         when(sseTaskStateContainerMock.getEmitter()).thenReturn(emitterMock);
         // We mock the EventMessageSupplier since it's tested in a separate test
-        when(eventMessageSupplierMock.get()).thenAnswer(i -> new EventMessageContext(itemQueue.poll(), false, new StreamLimit(), Mockito.mock(Span.class), Mockito.mock(Tracer.SpanInScope.class)));
+        when(eventMessageSupplierMock.get()).thenAnswer(i -> {
+            await().pollDelay(10, TimeUnit.MICROSECONDS).untilTrue(new AtomicBoolean(true));
+            return new EventMessageContext(itemQueue.poll(), false, new StreamLimit(), Mockito.mock(Span.class), Mockito.mock(Tracer.SpanInScope.class));
+        });
         when(eventMessageSupplierMock.getSubscriptionId()).thenReturn(MockHelper.TEST_SUBSCRIPTION_ID);
         // The following checks that we track a DELIVERED event with the de-duplication service
         // which is done in the callback of the eventwriter

--- a/src/test/java/de/telekom/horizon/pulsar/service/SseTaskTest.java
+++ b/src/test/java/de/telekom/horizon/pulsar/service/SseTaskTest.java
@@ -101,7 +101,7 @@ class SseTaskTest {
         when(sseTaskStateContainerMock.getEmitter()).thenReturn(emitterMock);
         // We mock the EventMessageSupplier since it's tested in a separate test
         when(eventMessageSupplierMock.get()).thenAnswer(i -> {
-            await().pollDelay(10, TimeUnit.MICROSECONDS).untilTrue(new AtomicBoolean(true));
+            await().pollDelay(10, TimeUnit.MILLISECONDS).untilTrue(new AtomicBoolean(true));
             return new EventMessageContext(itemQueue.poll(), false, new StreamLimit(), Mockito.mock(Span.class), Mockito.mock(Tracer.SpanInScope.class));
         });
         when(eventMessageSupplierMock.getSubscriptionId()).thenReturn(MockHelper.TEST_SUBSCRIPTION_ID);
@@ -187,7 +187,7 @@ class SseTaskTest {
         // We mock the EventMessageSupplier and let the mock always answer with a new event message to simulate
         // an endless stream
         when(eventMessageSupplierMock.get()).thenAnswer(i -> {
-            await().pollDelay(10, TimeUnit.MICROSECONDS).untilTrue(new AtomicBoolean(true));
+            await().pollDelay(10, TimeUnit.MILLISECONDS).untilTrue(new AtomicBoolean(true));
             return new EventMessageContext(MockHelper.createSubscriptionEventMessageForTesting(DeliveryType.SERVER_SENT_EVENT, false), false, streamLimit, Mockito.mock(Span.class), Mockito.mock(Tracer.SpanInScope.class));
         });
         when(eventMessageSupplierMock.getSubscriptionId()).thenReturn(MockHelper.TEST_SUBSCRIPTION_ID);
@@ -239,7 +239,7 @@ class SseTaskTest {
         // We mock the EventMessageSupplier and let the mock always answer with a new event message to simulate
         // an endless stream
         when(eventMessageSupplierMock.get()).thenAnswer(i -> {
-            await().pollDelay(10, TimeUnit.MICROSECONDS).untilTrue(new AtomicBoolean(true));
+            await().pollDelay(10, TimeUnit.MILLISECONDS).untilTrue(new AtomicBoolean(true));
             return new EventMessageContext(MockHelper.createSubscriptionEventMessageForTesting(DeliveryType.SERVER_SENT_EVENT, false), false, streamLimit, Mockito.mock(Span.class), Mockito.mock(Tracer.SpanInScope.class));
         });
         when(eventMessageSupplierMock.getSubscriptionId()).thenReturn(MockHelper.TEST_SUBSCRIPTION_ID);
@@ -288,7 +288,7 @@ class SseTaskTest {
         // We mock the EventMessageSupplier and let the mock always answer with a new event message to simulate
         // an endless stream
         when(eventMessageSupplierMock.get()).thenAnswer(i -> {
-            await().pollDelay(10, TimeUnit.MICROSECONDS).untilTrue(new AtomicBoolean(true));
+            await().pollDelay(10, TimeUnit.MILLISECONDS).untilTrue(new AtomicBoolean(true));
             return new EventMessageContext(MockHelper.createSubscriptionEventMessageForTesting(DeliveryType.SERVER_SENT_EVENT, false), false, streamLimit, Mockito.mock(Span.class), Mockito.mock(Tracer.SpanInScope.class));
         });
         when(eventMessageSupplierMock.getSubscriptionId()).thenReturn(MockHelper.TEST_SUBSCRIPTION_ID);
@@ -343,7 +343,7 @@ class SseTaskTest {
         // We mock the EventMessageSupplier and let the mock always answer with a new event message to simulate
         // an endless stream
         when(eventMessageSupplierMock.get()).thenAnswer(i -> {
-            await().pollDelay(10, TimeUnit.MICROSECONDS).untilTrue(new AtomicBoolean(true));
+            await().pollDelay(10, TimeUnit.MILLISECONDS).untilTrue(new AtomicBoolean(true));
 
             return new EventMessageContext(MockHelper.createSubscriptionEventMessageForTesting(DeliveryType.SERVER_SENT_EVENT, false), false, streamLimit, Mockito.mock(Span.class), Mockito.mock(Tracer.SpanInScope.class));
         });
@@ -397,7 +397,7 @@ class SseTaskTest {
         when(sseTaskStateContainerMock.getEmitter()).thenReturn(emitterMock);
         // We mock the EventMessageSupplier since it's tested in a separate test
         when(eventMessageSupplierMock.get()).thenAnswer(i -> {
-            await().pollDelay(10, TimeUnit.MICROSECONDS).untilTrue(new AtomicBoolean(true));
+            await().pollDelay(10, TimeUnit.MILLISECONDS).untilTrue(new AtomicBoolean(true));
             return new EventMessageContext(itemQueue.poll(), false, new StreamLimit(), Mockito.mock(Span.class), Mockito.mock(Tracer.SpanInScope.class));
         });
         when(eventMessageSupplierMock.getSubscriptionId()).thenReturn(MockHelper.TEST_SUBSCRIPTION_ID);

--- a/src/test/java/de/telekom/horizon/pulsar/service/SseTaskTest.java
+++ b/src/test/java/de/telekom/horizon/pulsar/service/SseTaskTest.java
@@ -38,7 +38,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Stream;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
@@ -77,11 +76,6 @@ class SseTaskTest {
         itemQueue.add(MockHelper.createSubscriptionEventMessageForTesting(DeliveryType.SERVER_SENT_EVENT, false));
 
         final var itemQueueInitialSize = itemQueue.size();
-
-        // We check whether a stream has been created successfully
-        // Since it is not accessible, we use ReflectionTestUtils
-        var stream = (Stream<EventMessageContext>) ReflectionTestUtils.getField(sseTaskSpy,"stream");
-        assertNotNull(stream);
 
         // We check whether an EventWriter has been created successfully
         // since it is not accessible, we use ReflectionTestUtils.

--- a/src/test/java/de/telekom/horizon/pulsar/service/SseTaskTest.java
+++ b/src/test/java/de/telekom/horizon/pulsar/service/SseTaskTest.java
@@ -98,7 +98,7 @@ class SseTaskTest {
         var emitterMock = mock(ResponseBodyEmitter.class);
         when(sseTaskStateContainerMock.getEmitter()).thenReturn(emitterMock);
         // We mock the EventMessageSupplier since it's tested in a separate test
-        when(eventMessageSupplierMock.get()).thenAnswer(i -> new EventMessageContext(itemQueue.poll(), false, any(StreamLimit.class), Mockito.mock(Span.class), Mockito.mock(Tracer.SpanInScope.class)));
+        when(eventMessageSupplierMock.get()).thenAnswer(i -> new EventMessageContext(itemQueue.poll(), false, new StreamLimit(), Mockito.mock(Span.class), Mockito.mock(Tracer.SpanInScope.class)));
         when(eventMessageSupplierMock.getSubscriptionId()).thenReturn(MockHelper.TEST_SUBSCRIPTION_ID);
         // The following checks that we track a DELIVERED event with the de-duplication service
         // which is done in the callback of the eventwriter

--- a/src/test/java/de/telekom/horizon/pulsar/service/SseTaskTest.java
+++ b/src/test/java/de/telekom/horizon/pulsar/service/SseTaskTest.java
@@ -15,6 +15,7 @@ import de.telekom.horizon.pulsar.exception.ConnectionCutOutException;
 import de.telekom.horizon.pulsar.exception.ConnectionTimeoutException;
 import de.telekom.horizon.pulsar.helper.EventMessageContext;
 import de.telekom.horizon.pulsar.helper.SseTaskStateContainer;
+import de.telekom.horizon.pulsar.helper.StreamLimit;
 import de.telekom.horizon.pulsar.testutils.MockHelper;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
@@ -97,7 +98,7 @@ class SseTaskTest {
         var emitterMock = mock(ResponseBodyEmitter.class);
         when(sseTaskStateContainerMock.getEmitter()).thenReturn(emitterMock);
         // We mock the EventMessageSupplier since it's tested in a separate test
-        when(eventMessageSupplierMock.get()).thenAnswer(i -> new EventMessageContext(itemQueue.poll(), false, Mockito.mock(Span.class), Mockito.mock(Tracer.SpanInScope.class)));
+        when(eventMessageSupplierMock.get()).thenAnswer(i -> new EventMessageContext(itemQueue.poll(), false, any(StreamLimit.class), Mockito.mock(Span.class), Mockito.mock(Tracer.SpanInScope.class)));
         when(eventMessageSupplierMock.getSubscriptionId()).thenReturn(MockHelper.TEST_SUBSCRIPTION_ID);
         // The following checks that we track a DELIVERED event with the de-duplication service
         // which is done in the callback of the eventwriter
@@ -178,7 +179,7 @@ class SseTaskTest {
 
         // We mock the EventMessageSupplier and let the mock always answer with a new event message to simulate
         // an endless stream
-        when(eventMessageSupplierMock.get()).thenAnswer(i -> new EventMessageContext(MockHelper.createSubscriptionEventMessageForTesting(DeliveryType.SERVER_SENT_EVENT, false), false, Mockito.mock(Span.class), Mockito.mock(Tracer.SpanInScope.class)));
+        when(eventMessageSupplierMock.get()).thenAnswer(i -> new EventMessageContext(MockHelper.createSubscriptionEventMessageForTesting(DeliveryType.SERVER_SENT_EVENT, false), false, new StreamLimit(), Mockito.mock(Span.class), Mockito.mock(Tracer.SpanInScope.class)));
         when(eventMessageSupplierMock.getSubscriptionId()).thenReturn(MockHelper.TEST_SUBSCRIPTION_ID);
         // The following checks that we track a DELIVERED event with the de-duplication service
         // which is done in the callback of the eventwriter
@@ -231,7 +232,7 @@ class SseTaskTest {
         var emitterMock = mock(ResponseBodyEmitter.class);
         when(sseTaskStateContainerMock.getEmitter()).thenReturn(emitterMock);
         // We mock the EventMessageSupplier since it's tested in a separate test
-        when(eventMessageSupplierMock.get()).thenAnswer(i -> new EventMessageContext(itemQueue.poll(), false, Mockito.mock(Span.class), Mockito.mock(Tracer.SpanInScope.class)));
+        when(eventMessageSupplierMock.get()).thenAnswer(i -> new EventMessageContext(itemQueue.poll(), false, new StreamLimit(), Mockito.mock(Span.class), Mockito.mock(Tracer.SpanInScope.class)));
         when(eventMessageSupplierMock.getSubscriptionId()).thenReturn(MockHelper.TEST_SUBSCRIPTION_ID);
         // The following checks that we track a DELIVERED event with the de-duplication service
         // which is done in the callback of the eventwriter


### PR DESCRIPTION
Added new query parameters that give the consumer more control over the termination of the stream.

These parameters make it possible to automatically terminate the stream:
- after n bytes consumed
- after n events consumed
- after n minutes

Also a new endpoint for terminating an existing stream on demand has been added.