### PR TITLE
fix: remove transfer encoding header 

### DIFF
--- a/src/main/java/de/telekom/horizon/pulsar/api/SseController.java
+++ b/src/main/java/de/telekom/horizon/pulsar/api/SseController.java
@@ -80,7 +80,6 @@ public class SseController {
 
         var responseHeaders = new HttpHeaders();
         responseHeaders.add(HttpHeaders.CONTENT_TYPE, accept);
-        responseHeaders.add(HttpHeaders.TRANSFER_ENCODING, "chunked");
         responseHeaders.add(HttpHeaders.CACHE_CONTROL, "no-cache");
         responseHeaders.add("X-Accel-Buffering", "no");
 


### PR DESCRIPTION
This change removes the transfer encoding header since only web servers or proxies should be in charge of that header.
In fact Tomcat already adds this header automatically when content-length is not set. So, before we ended up with a duplicate header which can lead to issues.
For example in curl v8.x in windows this _extra_ header broke the consumption of events.