### PR TITLE
feat: add new metric to monitor deliveries

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 fabric8Version=5.12.4
-horizonParentVersion=4.1.0
+horizonParentVersion=0.0.0-feature-new-sse-metric-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 fabric8Version=5.12.4
-horizonParentVersion=0.0.0-feature-new-sse-metric-SNAPSHOT
+horizonParentVersion=4.3.0

--- a/src/main/java/de/telekom/horizon/pulsar/service/EventMessageSupplier.java
+++ b/src/main/java/de/telekom/horizon/pulsar/service/EventMessageSupplier.java
@@ -128,7 +128,6 @@ public class EventMessageSupplier implements Supplier<EventMessageContext> {
                 }
 
                 metricsHelper.getRegistry().counter(METRIC_SENT_SSE_EVENTS, metricsHelper.buildTagsFromSubscriptionEventMessage(message)).increment();
-                span.annotate("export metrics");
 
                 return new EventMessageContext(message, includeHttpHeaders, streamLimit, span, spanInScope);
             } catch (CouldNotPickMessageException | SubscriberDoesNotMatchSubscriptionException e) {

--- a/src/main/java/de/telekom/horizon/pulsar/service/EventMessageSupplier.java
+++ b/src/main/java/de/telekom/horizon/pulsar/service/EventMessageSupplier.java
@@ -63,7 +63,6 @@ public class EventMessageSupplier implements Supplier<EventMessageContext> {
     private final EventWriter eventWriter;
     private final MessageStateMongoRepo messageStateMongoRepo;
     private final HorizonTracer tracingHelper;
-    private final HorizonMetricsHelper metricsHelper;
     private final ConcurrentLinkedQueue<State> messageStates = new ConcurrentLinkedQueue<>();
     private Instant lastPoll;
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -82,7 +81,6 @@ public class EventMessageSupplier implements Supplier<EventMessageContext> {
         this.messageStateMongoRepo = factory.getMessageStateMongoRepo();
         this.kafkaPicker = factory.getKafkaPicker();
         this.eventWriter = factory.getEventWriter();
-        this.metricsHelper = factory.getMetricsHelper();
         this.tracingHelper = factory.getTracingHelper();
         this.includeHttpHeaders = includeHttpHeaders;
         this.streamLimit = streamLimit;
@@ -126,8 +124,6 @@ public class EventMessageSupplier implements Supplier<EventMessageContext> {
                         throw new SubscriberDoesNotMatchSubscriptionException(errorMessage);
                     }
                 }
-
-                metricsHelper.getRegistry().counter(METRIC_SENT_SSE_EVENTS, metricsHelper.buildTagsFromSubscriptionEventMessage(message)).increment();
 
                 return new EventMessageContext(message, includeHttpHeaders, streamLimit, span, spanInScope);
             } catch (CouldNotPickMessageException | SubscriberDoesNotMatchSubscriptionException e) {

--- a/src/main/java/de/telekom/horizon/pulsar/service/EventMessageSupplier.java
+++ b/src/main/java/de/telekom/horizon/pulsar/service/EventMessageSupplier.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.telekom.eni.pandora.horizon.kafka.event.EventWriter;
-import de.telekom.eni.pandora.horizon.metrics.HorizonMetricsHelper;
 import de.telekom.eni.pandora.horizon.model.db.State;
 import de.telekom.eni.pandora.horizon.model.event.DeliveryType;
 import de.telekom.eni.pandora.horizon.model.event.Status;
@@ -38,8 +37,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Supplier;
-
-import static de.telekom.eni.pandora.horizon.metrics.HorizonMetricsConstants.METRIC_SENT_SSE_EVENTS;
 
 /**
  * Supplier for providing {@link EventMessageContext} instances.

--- a/src/main/java/de/telekom/horizon/pulsar/service/SseTaskFactory.java
+++ b/src/main/java/de/telekom/horizon/pulsar/service/SseTaskFactory.java
@@ -6,6 +6,7 @@ package de.telekom.horizon.pulsar.service;
 
 import de.telekom.eni.pandora.horizon.cache.service.DeDuplicationService;
 import de.telekom.eni.pandora.horizon.kafka.event.EventWriter;
+import de.telekom.eni.pandora.horizon.metrics.HorizonMetricsHelper;
 import de.telekom.eni.pandora.horizon.mongo.repository.MessageStateMongoRepo;
 import de.telekom.eni.pandora.horizon.tracing.HorizonTracer;
 import de.telekom.horizon.pulsar.cache.ConnectionCache;
@@ -36,6 +37,7 @@ public class SseTaskFactory {
     private final DeDuplicationService deDuplicationService;
     private final HorizonTracer tracingHelper;
     private final EventWriter eventWriter;
+    private final HorizonMetricsHelper metricsHelper;
 
     /**
      * Constructs an instance of {@code SseTaskFactory}.
@@ -57,6 +59,7 @@ public class SseTaskFactory {
             KafkaPicker kafkaPicker,
             MessageStateMongoRepo messageStateMongoRepo,
             DeDuplicationService deDuplicationService,
+            HorizonMetricsHelper metricsHelper,
             HorizonTracer tracingHelper) {
 
         this.pulsarConfig = pulsarConfig;
@@ -68,6 +71,7 @@ public class SseTaskFactory {
         this.deDuplicationService = deDuplicationService;
 
         this.eventWriter = eventWriter;
+        this.metricsHelper = metricsHelper;
     }
 
     /**

--- a/src/main/java/de/telekom/horizon/pulsar/service/SseTaskFactory.java
+++ b/src/main/java/de/telekom/horizon/pulsar/service/SseTaskFactory.java
@@ -69,7 +69,6 @@ public class SseTaskFactory {
         this.tracingHelper = tracingHelper;
         this.connectionCache = connectionCache;
         this.deDuplicationService = deDuplicationService;
-
         this.eventWriter = eventWriter;
         this.metricsHelper = metricsHelper;
     }

--- a/src/test/java/de/telekom/horizon/pulsar/service/EventMessageSupplierTest.java
+++ b/src/test/java/de/telekom/horizon/pulsar/service/EventMessageSupplierTest.java
@@ -34,7 +34,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
-import static de.telekom.horizon.pulsar.testutils.MockHelper.metricsHelper;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -86,12 +85,6 @@ class EventMessageSupplierTest {
         // Since we want to check invocations with it, we will overwrite the EventWriter in EventMessageSupplier via reflections
         var eventWriterMock = mock(EventWriter.class);
         ReflectionTestUtils.setField(eventMessageSupplier, "eventWriter", eventWriterMock, EventWriter.class);
-
-        var counterMock = Mockito.mock(Counter.class);
-        var registryMock = Mockito.mock(MeterRegistry.class);
-        when(registryMock.counter(any(), any(Tags.class))).thenReturn(counterMock);
-        when(metricsHelper.buildTagsFromSubscriptionEventMessage(any())).thenReturn(Tags.empty());
-        when(metricsHelper.getRegistry()).thenReturn(registryMock);
 
         // We do multiple calls to EventMessageSupplier.get() in order to test
         // that each call will fetch the next event message in the queue

--- a/src/test/java/de/telekom/horizon/pulsar/service/SseTaskFactoryTest.java
+++ b/src/test/java/de/telekom/horizon/pulsar/service/SseTaskFactoryTest.java
@@ -38,7 +38,7 @@ class SseTaskFactoryTest {
     void setupSseTaskFactoryTest() {
         MockHelper.init();
 
-        sseTaskFactorySpy = spy(new SseTaskFactory(MockHelper.pulsarConfig, MockHelper.connectionCache, MockHelper.connectionGaugeCache, MockHelper.eventWriter, MockHelper.kafkaPicker, MockHelper.messageStateMongoRepo, MockHelper.deDuplicationService, MockHelper.tracingHelper));
+        sseTaskFactorySpy = spy(new SseTaskFactory(MockHelper.pulsarConfig, MockHelper.connectionCache, MockHelper.connectionGaugeCache, MockHelper.eventWriter, MockHelper.kafkaPicker, MockHelper.messageStateMongoRepo, MockHelper.deDuplicationService, MockHelper.metricsHelper, MockHelper.tracingHelper));
     }
 
     SubscriptionResource createSubscriptionResource() {

--- a/src/test/java/de/telekom/horizon/pulsar/service/SseTaskTest.java
+++ b/src/test/java/de/telekom/horizon/pulsar/service/SseTaskTest.java
@@ -18,6 +18,9 @@ import de.telekom.horizon.pulsar.helper.EventMessageContext;
 import de.telekom.horizon.pulsar.helper.SseTaskStateContainer;
 import de.telekom.horizon.pulsar.helper.StreamLimit;
 import de.telekom.horizon.pulsar.testutils.MockHelper;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,6 +42,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static de.telekom.horizon.pulsar.testutils.MockHelper.metricsHelper;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -59,7 +63,6 @@ class SseTaskTest {
         MockHelper.init();
 
         var sseTask = new SseTask(sseTaskStateContainerMock, eventMessageSupplierMock, MockHelper.openConnectionGaugeValue, MockHelper.sseTaskFactory);
-
         sseTaskSpy = spy(sseTask);
     }
 
@@ -107,6 +110,12 @@ class SseTaskTest {
 
         // Used for verifying the timout worked
         var started = Instant.now();
+
+        var counterMock = Mockito.mock(Counter.class);
+        var registryMock = Mockito.mock(MeterRegistry.class);
+        when(registryMock.counter(any(), any(Tags.class))).thenReturn(counterMock);
+        when(metricsHelper.buildTagsFromSubscriptionEventMessage(any())).thenReturn(Tags.empty());
+        when(metricsHelper.getRegistry()).thenReturn(registryMock);
 
         // PUBLIC METHOD WE WANT TO TEST
         sseTaskSpy.run();
@@ -191,6 +200,12 @@ class SseTaskTest {
         var succeededFuture = CompletableFuture.completedFuture(sendResult);
         when(eventWriterMock.send(anyString(), notNull(), any())).thenReturn(succeededFuture);
 
+        var counterMock = Mockito.mock(Counter.class);
+        var registryMock = Mockito.mock(MeterRegistry.class);
+        when(registryMock.counter(any(), any(Tags.class))).thenReturn(counterMock);
+        when(metricsHelper.buildTagsFromSubscriptionEventMessage(any())).thenReturn(Tags.empty());
+        when(metricsHelper.getRegistry()).thenReturn(registryMock);
+
         sseTaskSpy.run();
 
         var reachedZero = latch.await(10000, TimeUnit.MILLISECONDS);
@@ -243,6 +258,12 @@ class SseTaskTest {
         var succeededFuture = CompletableFuture.completedFuture(sendResult);
         when(eventWriterMock.send(anyString(), notNull(), any())).thenReturn(succeededFuture);
 
+        var counterMock = Mockito.mock(Counter.class);
+        var registryMock = Mockito.mock(MeterRegistry.class);
+        when(registryMock.counter(any(), any(Tags.class))).thenReturn(counterMock);
+        when(metricsHelper.buildTagsFromSubscriptionEventMessage(any())).thenReturn(Tags.empty());
+        when(metricsHelper.getRegistry()).thenReturn(registryMock);
+
         sseTaskSpy.run();
 
         verify(emitterMock, times(maxNumberLimit)).send(anyString());
@@ -291,6 +312,12 @@ class SseTaskTest {
         SendResult<String, String> sendResult = mock(SendResult.class);
         var succeededFuture = CompletableFuture.completedFuture(sendResult);
         when(eventWriterMock.send(anyString(), notNull(), any())).thenReturn(succeededFuture);
+
+        var counterMock = Mockito.mock(Counter.class);
+        var registryMock = Mockito.mock(MeterRegistry.class);
+        when(registryMock.counter(any(), any(Tags.class))).thenReturn(counterMock);
+        when(metricsHelper.buildTagsFromSubscriptionEventMessage(any())).thenReturn(Tags.empty());
+        when(metricsHelper.getRegistry()).thenReturn(registryMock);
 
         sseTaskSpy.run();
 
@@ -347,6 +374,12 @@ class SseTaskTest {
         SendResult<String, String> sendResult = mock(SendResult.class);
         var succeededFuture = CompletableFuture.completedFuture(sendResult);
         when(eventWriterMock.send(anyString(), notNull(), any())).thenReturn(succeededFuture);
+
+        var counterMock = Mockito.mock(Counter.class);
+        var registryMock = Mockito.mock(MeterRegistry.class);
+        when(registryMock.counter(any(), any(Tags.class))).thenReturn(counterMock);
+        when(metricsHelper.buildTagsFromSubscriptionEventMessage(any())).thenReturn(Tags.empty());
+        when(metricsHelper.getRegistry()).thenReturn(registryMock);
 
         sseTaskSpy.run();
 

--- a/src/test/java/de/telekom/horizon/pulsar/testutils/MockHelper.java
+++ b/src/test/java/de/telekom/horizon/pulsar/testutils/MockHelper.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import de.telekom.eni.pandora.horizon.cache.service.DeDuplicationService;
 import de.telekom.eni.pandora.horizon.kafka.config.KafkaProperties;
 import de.telekom.eni.pandora.horizon.kafka.event.EventWriter;
+import de.telekom.eni.pandora.horizon.metrics.HorizonMetricsHelper;
 import de.telekom.eni.pandora.horizon.model.db.Coordinates;
 import de.telekom.eni.pandora.horizon.model.db.PartialEvent;
 import de.telekom.eni.pandora.horizon.model.db.State;
@@ -62,6 +63,7 @@ public class MockHelper {
     public static Environment environment;
     public static ResponseBodyEmitter emitter;
     public static TokenService tokenService;
+    public static HorizonMetricsHelper metricsHelper;
 
     public static DeDuplicationService deDuplicationService;
 
@@ -99,7 +101,7 @@ public class MockHelper {
         lenient().when(pulsarConfig.getQueueCapacity()).thenReturn(100);
 
         kafkaPicker = new KafkaPicker(kafkaTemplate);
-        sseTaskFactory = new SseTaskFactory(pulsarConfig, connectionCache, connectionGaugeCache, eventWriter, kafkaPicker, messageStateMongoRepo, deDuplicationService, tracingHelper);
+        sseTaskFactory = new SseTaskFactory(pulsarConfig, connectionCache, connectionGaugeCache, eventWriter, kafkaPicker, messageStateMongoRepo, deDuplicationService, metricsHelper, tracingHelper);
     }
 
     public static SubscriptionEventMessage createSubscriptionEventMessageForTesting(DeliveryType deliveryType, boolean withAdditionalFields) {

--- a/src/test/java/de/telekom/horizon/pulsar/testutils/MockHelper.java
+++ b/src/test/java/de/telekom/horizon/pulsar/testutils/MockHelper.java
@@ -87,6 +87,7 @@ public class MockHelper {
         subscriberCache = mock(SubscriberCache.class);
         pulsarConfig = mock(PulsarConfig.class);
         messageStateMongoRepo = mock(MessageStateMongoRepo.class);
+        metricsHelper = mock(HorizonMetricsHelper.class);
         tracingHelper = mock(HorizonTracer.class);
         environment = mock(Environment.class);
         emitter = mock(ResponseBodyEmitter.class);


### PR DESCRIPTION
- add new metric to monitor deliveries
- update parent version to 4.3.0 with new metric called SENT_SSE_EVENTS
- fix tests with metricsHelper