### PR TITLE
fix(metric-tag): modified environment tag for metric, when subscriptions environment is set to 'default'

### DIFF
--- a/src/main/java/de/telekom/horizon/pulsar/cache/ConnectionGaugeCache.java
+++ b/src/main/java/de/telekom/horizon/pulsar/cache/ConnectionGaugeCache.java
@@ -69,7 +69,8 @@ public class ConnectionGaugeCache {
      * @return Tags for identifying SSE subscriptions in metrics.
      */
     private Tags buildTagsForSseSubscription(SubscriptionResource resource) {
-        var environment = Optional.ofNullable(resource.getSpec().getEnvironment()).orElse(pulsarConfig.getDefaultEnvironment());
+        var resourceEnvironment = Optional.ofNullable(resource.getSpec().getEnvironment()).orElse("default");
+        var environment = !resourceEnvironment.equals("default") ? resourceEnvironment : pulsarConfig.getDefaultEnvironment();
 
         return Tags.of(
                 TAG_ENVIRONMENT, environment,


### PR DESCRIPTION
- fix handling of default environment in metrics