### PR TITLE
docs: add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ SPDX-License-Identifier: Apache-2.0
 [![REUSE status](https://api.reuse.software/badge/github.com/telekom/pubsub-horizon-pulsar)](https://api.reuse.software/info/github.com/telekom/pubsub-horizon-pulsar)
 -->
 [![Gradle Build and Test](https://github.com/telekom/pubsub-horizon-pulsar/actions/workflows/gradle-build.yml/badge.svg)](https://github.com/telekom/pubsub-horizon-pulsar/actions/workflows/gradle-build.yml)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/telekom/pubsub-horizon-pulsar)
 
 ## Overview
 Pulsar is a Horizon component that is responsible for the SSE delivery of event messages to customers that actively call the /sse 


### PR DESCRIPTION
## Summary
- Add DeepWiki badge to README for AI-powered documentation exploration