### PR TITLE
feat(pulsar): add graceful shutdown support

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -17,14 +17,14 @@ jobs:
         image: docker:25-dind
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 21
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3
 
       - name: Configure init.gradle
         run: |
@@ -35,7 +35,7 @@ jobs:
 
       - name: Add coverage to PR
         id: jacoco
-        uses: madrapps/jacoco-report@v1.6.1
+        uses: madrapps/jacoco-report@db72e7e7c96f98d239967958b0a0a6ca7d3bb45f # v1.6.1
         with:
           paths: |
             ${{ github.workspace }}/**/build/reports/jacoco/**/jacocoTestReport.xml

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -10,6 +10,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - name: REUSE Compliance Check
-      uses: fsfe/reuse-action@v1
+      uses: fsfe/reuse-action@28cf8f33bc50f4c306f52e38fe3826717dea63dc # v1

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,6 +8,11 @@ spring:
       request-timeout: -1
   application:
     name: Horizon Pulsar
+  lifecycle:
+    timeout-per-shutdown-phase: ${PULSAR_GRACEFUL_SHUTDOWN_TIMEOUT:60000}ms
+
+server:
+  shutdown: graceful
 
 logging:
   level:

--- a/src/test/java/de/telekom/horizon/pulsar/config/GracefulShutdownConfigTest.java
+++ b/src/test/java/de/telekom/horizon/pulsar/config/GracefulShutdownConfigTest.java
@@ -1,0 +1,42 @@
+// Copyright 2024 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package de.telekom.horizon.pulsar.config;
+
+import de.telekom.horizon.pulsar.testutils.HazelcastTestInstance;
+import de.telekom.horizon.pulsar.utils.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.embedded.tomcat.TomcatWebServer;
+import org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith({HazelcastTestInstance.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class GracefulShutdownConfigTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private ServletWebServerApplicationContext applicationContext;
+
+    @Test
+    void webServerIsConfiguredForGracefulShutdown() {
+        var webServer = applicationContext.getWebServer();
+        assertTrue(webServer instanceof TomcatWebServer, "Expected TomcatWebServer");
+
+        var shutdown = applicationContext.getEnvironment().getProperty("server.shutdown");
+        assertEquals("graceful", shutdown);
+    }
+
+    @Test
+    void shutdownTimeoutIsConfigured() {
+        var timeout = applicationContext.getEnvironment()
+                .getProperty("spring.lifecycle.timeout-per-shutdown-phase");
+        assertTrue(timeout != null && timeout.contains("60000"),
+                "Expected shutdown phase timeout of 60000ms, got: " + timeout);
+    }
+}

--- a/src/test/java/de/telekom/horizon/pulsar/config/GracefulShutdownIntegrationTest.java
+++ b/src/test/java/de/telekom/horizon/pulsar/config/GracefulShutdownIntegrationTest.java
@@ -1,0 +1,112 @@
+// Copyright 2024 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package de.telekom.horizon.pulsar.config;
+
+import de.telekom.horizon.pulsar.testutils.HazelcastTestInstance;
+import de.telekom.horizon.pulsar.utils.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.GracefulShutdownResult;
+import org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration test that verifies graceful shutdown with actual HTTP connections.
+ *
+ * Tests that:
+ * 1. In-flight requests complete successfully during shutdown
+ * 2. The server drains connections before stopping
+ */
+@ExtendWith({HazelcastTestInstance.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class GracefulShutdownIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private ServletWebServerApplicationContext applicationContext;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @DynamicPropertySource
+    static void dynamicProperties(DynamicPropertyRegistry registry) {
+        registry.add("pulsar.security.oauth", () -> false);
+    }
+
+    @TestConfiguration
+    static class SlowEndpointConfig {
+        /**
+         * Test-only controller that simulates a slow in-flight request.
+         */
+        @RestController
+        static class SlowController {
+            static final CountDownLatch requestStarted = new CountDownLatch(1);
+            static final CountDownLatch allowComplete = new CountDownLatch(1);
+
+            @GetMapping("/test/slow")
+            public String slow() throws InterruptedException {
+                requestStarted.countDown();
+                // Block until the test signals completion (or timeout)
+                allowComplete.await(10, TimeUnit.SECONDS);
+                return "completed";
+            }
+        }
+    }
+
+    @Test
+    void inFlightRequestCompletesAfterGracefulShutdown() throws Exception {
+        var webServer = applicationContext.getWebServer();
+        var responseRef = new AtomicReference<ResponseEntity<String>>();
+        var shutdownResultRef = new AtomicReference<GracefulShutdownResult>();
+
+        // 1. Start a slow request in a background thread
+        var requestFuture = CompletableFuture.runAsync(() -> {
+            responseRef.set(restTemplate.getForEntity("/test/slow", String.class));
+        });
+
+        // 2. Wait for the request to actually hit the server
+        assertTrue(
+                SlowEndpointConfig.SlowController.requestStarted.await(5, TimeUnit.SECONDS),
+                "Slow request should have started"
+        );
+
+        // 3. Trigger graceful shutdown while request is in-flight
+        webServer.shutDownGracefully(result -> shutdownResultRef.set(result));
+
+        // 4. Let the in-flight request complete
+        SlowEndpointConfig.SlowController.allowComplete.countDown();
+
+        // 5. Wait for the request to finish
+        requestFuture.get(10, TimeUnit.SECONDS);
+
+        // 6. Verify the in-flight request completed successfully
+        var response = responseRef.get();
+        assertNotNull(response, "Response should not be null");
+        assertEquals(HttpStatus.OK, response.getStatusCode(),
+                "In-flight request should complete with 200 during graceful shutdown");
+        assertEquals("completed", response.getBody());
+
+        // 7. Verify shutdown completed successfully (all requests drained)
+        // Give it a moment to finalize
+        Thread.sleep(500);
+        assertEquals(GracefulShutdownResult.IDLE, shutdownResultRef.get(),
+                "Shutdown should report IDLE after all requests drained");
+    }
+}


### PR DESCRIPTION
## Summary
- Enable Spring Boot graceful shutdown (`server.shutdown=graceful`) with 60s timeout matching SSE idle timeout
- Add integration tests verifying in-flight requests complete during shutdown

## Shutdown sequence
1. K8s preStop `sleep 15` — pod removed from endpoints
2. SIGTERM — Spring stops accepting new requests
3. In-flight SSE connections drain (up to 60s)
4. JVM exits. Total budget: 15 + 60 + 5s buffer = 80s `terminationGracePeriodSeconds`

## Test plan
- [x] `GracefulShutdownConfigTest` verifies config properties
- [x] `GracefulShutdownIntegrationTest` verifies in-flight HTTP request survives `shutDownGracefully()`
- [x] Full test suite passes
- [x] Fully tested on integration