### PR TITLE
fix(pulsar): upgrade MongoDB driver and improve SSE stream resilience

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 plugins {
-    id 'org.springframework.boot' version '3.2.3'
+    id 'org.springframework.boot' version '3.4.2'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'java'
     id "jacoco"
@@ -51,7 +51,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
     testImplementation 'org.springframework.security:spring-security-test'
-    testImplementation "de.bwaldvogel:mongo-java-server:1.44.0"
+    testImplementation "de.bwaldvogel:mongo-java-server:1.46.0"
 
     //3rd party
     annotationProcessor "org.projectlombok:lombok"

--- a/src/main/java/de/telekom/horizon/pulsar/api/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/de/telekom/horizon/pulsar/api/RestResponseEntityExceptionHandler.java
@@ -118,6 +118,13 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
     })
     @ResponseStatus(HttpStatus.GATEWAY_TIMEOUT)
     protected ResponseEntity<Object> handleTimeout(Exception e, WebRequest request) {
+        // SSE streams commit the response immediately (200 + flush). When idle timeout fires,
+        // the response is already committed so we can't change it to 504 — just log and return.
+        if (request instanceof org.springframework.web.context.request.ServletWebRequest swr
+                && swr.getResponse() != null && swr.getResponse().isCommitted()) {
+            log.info("SSE idle timeout — response already committed");
+            return null;
+        }
         return responseEntityForException(e, HttpStatus.GATEWAY_TIMEOUT, HttpStatus.GATEWAY_TIMEOUT.getReasonPhrase(), request, null);
     }
 

--- a/src/main/java/de/telekom/horizon/pulsar/config/PulsarConfig.java
+++ b/src/main/java/de/telekom/horizon/pulsar/config/PulsarConfig.java
@@ -32,4 +32,10 @@ public class PulsarConfig {
 
     @Value("${pulsar.defaultEnvironment}")
     private String defaultEnvironment;
+
+    @Value("${pulsar.mongo.maxRetries:1}")
+    private int mongoMaxRetries;
+
+    @Value("${pulsar.mongo.retryDelayMs:100}")
+    private long mongoRetryDelayMs;
 }

--- a/src/main/java/de/telekom/horizon/pulsar/config/rest/WebSecurityConfig.java
+++ b/src/main/java/de/telekom/horizon/pulsar/config/rest/WebSecurityConfig.java
@@ -62,7 +62,8 @@ public class WebSecurityConfig {
             http.authorizeHttpRequests(authorizeRequests -> authorizeRequests
                             .requestMatchers(toAnyEndpoint()).permitAll()
                             .requestMatchers(HttpMethod.HEAD, "/v1/**").permitAll()
-                            .requestMatchers( "/v1/**").authenticated())
+                            .requestMatchers("/error").permitAll() // prevent AccessDeniedException when Spring forwards to /error internally
+                            .requestMatchers("/v1/**").authenticated())
                     .oauth2ResourceServer(oauth2 -> oauth2.authenticationManagerResolver(jwtIssuerAuthenticationManagerResolver));
         } else {
             // Allow all requests without authentication if OAuth2 is disabled

--- a/src/main/java/de/telekom/horizon/pulsar/service/EventMessageSupplier.java
+++ b/src/main/java/de/telekom/horizon/pulsar/service/EventMessageSupplier.java
@@ -5,7 +5,6 @@
 package de.telekom.horizon.pulsar.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.telekom.eni.pandora.horizon.kafka.event.EventWriter;
 import de.telekom.eni.pandora.horizon.model.db.State;
@@ -121,17 +120,23 @@ public class EventMessageSupplier implements Supplier<EventMessageContext> {
 
                 var message = deserializeSubscriptionEventMessage(rec.value(), state);
 
-                if (message != null) {
-                    tracingHelper.addTagsToSpanFromSubscriptionEventMessage(pickSpan, message);
-
-                    // we do a sanity check here that checks whether metadata and event message fit to each other
-                    if (!subscriptionId.equals(message.getSubscriptionId())) {
-                        var errorMessage = String.format("Event message %s did not match subscriptionId %s", state.getUuid(), state.getSubscriptionId());
-                        throw new SubscriberDoesNotMatchSubscriptionException(errorMessage);
-                    }
-
-                    Optional.ofNullable(message.getHttpHeaders()).ifPresent(headers -> headers.put("x-pubsub-offset-id", new ArrayList<>(List.of(state.getUuid()))));
+                if (message == null) {
+                    // Deserialization failed — mark as FAILED to prevent infinite re-poll
+                    handleException(state, new CouldNotPickMessageException(
+                            new CouldNotFindEventMessageException("Deserialization failed for event " + state.getUuid())));
+                    return new EventMessageContext(null, includeHttpHeaders, streamLimit, ignoreDeduplication, span, spanInScope);
                 }
+
+                tracingHelper.addTagsToSpanFromSubscriptionEventMessage(pickSpan, message);
+
+                // we do a sanity check here that checks whether metadata and event message fit to each other
+                if (!subscriptionId.equals(message.getSubscriptionId())) {
+                    var errorMessage = String.format("Event message %s did not match subscriptionId %s", state.getUuid(), state.getSubscriptionId());
+                    throw new SubscriberDoesNotMatchSubscriptionException(errorMessage);
+                }
+
+                Optional.ofNullable(message.getHttpHeaders()).ifPresent(headers -> headers.put("x-pubsub-offset-id", new ArrayList<>(List.of(state.getUuid()))));
+
                 return new EventMessageContext(message, includeHttpHeaders, streamLimit, ignoreDeduplication, span, spanInScope);
             } catch (CouldNotPickMessageException | SubscriberDoesNotMatchSubscriptionException e) {
                 handleException(state, e);
@@ -161,24 +166,32 @@ public class EventMessageSupplier implements Supplier<EventMessageContext> {
                         cause instanceof CorruptRecordException ||
                         cause instanceof IllegalArgumentException
         ) {
+            log.warn("Event {} failed permanently — {}: {}",
+                    state.getUuid(),
+                    Optional.ofNullable(cause).orElse(e).getClass().getSimpleName(),
+                    Optional.ofNullable(cause).orElse(e).getMessage());
             try {
                 var status = Status.FAILED;
                 var statusMessage = new StatusMessage(state.getUuid(), state.getEvent().getId(), status, state.getDeliveryType());
                 statusMessage.withThrowable(Optional.ofNullable(e.getCause()).orElse(e));
                 eventWriter.send(Objects.requireNonNullElse(state.getEventRetentionTime(), EventRetentionTime.DEFAULT).getTopic(), statusMessage, tracingHelper);
                 currentSpan.ifPresent(s -> {
+                    var errorSource = Optional.ofNullable(cause).orElse(e);
+                    var errorMsg = errorSource.getMessage() != null
+                            ? errorSource.getMessage() : errorSource.getClass().getSimpleName();
                     tracingHelper.addTagsToSpan(s, List.of(
                             Pair.of("status", status.name()),
-                            Pair.of("error", Optional.ofNullable(e.getCause()).orElse(e).getMessage())
+                            Pair.of("error", errorMsg)
                     ));
                 });
             } catch (Exception e1) {
-                var err = String.format("Error occurred while updating the event status: %s", e1.getMessage());
-                log.error(err, e1);
+                log.error("Failed to write FAILED status for event {} — {}: {}",
+                        state.getUuid(), e1.getClass().getSimpleName(), e1.getMessage(), e1);
             }
+        } else {
+            log.error("Unexpected error picking event {} — {}: {}",
+                    state.getUuid(), e.getClass().getSimpleName(), e.getMessage(), e);
         }
-
-        log.error("Could not pick event, error: {}", e.getMessage());
     }
 
     /**
@@ -191,46 +204,78 @@ public class EventMessageSupplier implements Supplier<EventMessageContext> {
         if (messageStates.isEmpty()) {
             delay();
 
-            Pageable pageable = PageRequest.of(0, pulsarConfig.getSseBatchSize(), Sort.by(Sort.Direction.ASC, "timestamp"));
-
-            Optional<MessageStateMongoDocument> offsetMsg = Optional.empty();
-            if (StringUtils.isNoneEmpty(currentOffset)) {
-                offsetMsg = messageStateMongoRepo.findById(currentOffset);
-            }
-
-            if (offsetMsg.isPresent()) {
-                var offsetTimestamp = offsetMsg.get().getTimestamp();
-
-                var list = messageStateMongoRepo.findByDeliveryTypeAndSubscriptionIdAndTimestampGreaterThanAsc(
-                                DeliveryType.SERVER_SENT_EVENT,
-                                subscriptionId,
-                                offsetTimestamp,
-                                pageable
-                        ).stream()
-                        .filter(m -> m.getCoordinates() != null) // we skip messages that refer to -1 partitions and offsets
-                        .toList();
-
-                messageStates.addAll(list);
-
-                if (!list.isEmpty()) {
-                    currentOffset = list.getLast().getUuid();
+            // Retry on transient MongoDB failures. PrivateLink connection drops cause
+            // IllegalStateException from the driver's connection pool when an in-flight query races
+            // with pool invalidation. The pool recovers within ms, so a single retry with jitter
+            // is enough to survive the blip without killing the customer's SSE stream.
+            // Catches broad Exception because the driver may wrap differently across versions.
+            int retriesLeft = pulsarConfig.getMongoMaxRetries();
+            while (true) {
+                try {
+                    doPollMessageStates();
+                    break;
+                } catch (Exception e) {
+                    if (retriesLeft-- <= 0) throw e;
+                    log.warn("MongoDB poll failed, retrying ({} left) — {}: {}",
+                            retriesLeft, e.getClass().getSimpleName(), e.getMessage());
+                    try {
+                        // Jitter prevents thundering herd when all SSE threads fail simultaneously
+                        long delay = pulsarConfig.getMongoRetryDelayMs();
+                        Thread.sleep(delay / 2 + (long) (Math.random() * delay / 2));
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(ie);
+                    }
                 }
-            } else {
-                currentOffset = null;
-
-                var list = messageStateMongoRepo.findByStatusInAndDeliveryTypeAndSubscriptionIdAsc(
-                                List.of(Status.PROCESSED),
-                                DeliveryType.SERVER_SENT_EVENT,
-                                subscriptionId,
-                                pageable
-                        ).stream()
-                        .filter(m -> m.getCoordinates() != null) // we skip messages that refer to -1 partitions and offsets
-                        .toList();
-
-                messageStates.addAll(list);
             }
 
             lastPoll = Instant.now();
+        }
+    }
+
+    private void doPollMessageStates() {
+        Pageable pageable = PageRequest.of(0, pulsarConfig.getSseBatchSize(), Sort.by(Sort.Direction.ASC, "timestamp"));
+
+        Optional<MessageStateMongoDocument> offsetMsg = Optional.empty();
+        if (StringUtils.isNoneEmpty(currentOffset)) {
+            offsetMsg = messageStateMongoRepo.findById(currentOffset);
+        }
+
+        if (offsetMsg.isPresent()) {
+            var offsetTimestamp = offsetMsg.get().getTimestamp();
+
+            var rawList = messageStateMongoRepo.findByDeliveryTypeAndSubscriptionIdAndTimestampGreaterThanAsc(
+                            DeliveryType.SERVER_SENT_EVENT,
+                            subscriptionId,
+                            offsetTimestamp,
+                            pageable
+                    ).stream()
+                    .filter(m -> m.getCoordinates() != null)
+                    .toList();
+
+            // Advance offset past all returned results (including FAILED) to avoid re-polling the same batch
+            if (!rawList.isEmpty()) {
+                currentOffset = rawList.getLast().getUuid();
+            }
+
+            var list = rawList.stream()
+                    .filter(m -> m.getStatus() != Status.FAILED)
+                    .toList();
+
+            messageStates.addAll(list);
+        } else {
+            currentOffset = null;
+
+            var list = messageStateMongoRepo.findByStatusInAndDeliveryTypeAndSubscriptionIdAsc(
+                            List.of(Status.PROCESSED),
+                            DeliveryType.SERVER_SENT_EVENT,
+                            subscriptionId,
+                            pageable
+                    ).stream()
+                    .filter(m -> m.getCoordinates() != null) // we skip messages that refer to -1 partitions and offsets
+                    .toList();
+
+            messageStates.addAll(list);
         }
     }
 
@@ -250,7 +295,7 @@ public class EventMessageSupplier implements Supplier<EventMessageContext> {
         try {
             Thread.sleep(sleepTime);
         } catch (InterruptedException e) {
-            log.error(e.getMessage(), e);
+            log.debug("Poll delay interrupted");
             Thread.currentThread().interrupt();
         }
     }
@@ -265,10 +310,9 @@ public class EventMessageSupplier implements Supplier<EventMessageContext> {
     private SubscriptionEventMessage deserializeSubscriptionEventMessage(String json, State state) {
         try {
             return objectMapper.readValue(json, SubscriptionEventMessage.class);
-        } catch (JsonMappingException e) {
-            log.error("Could not deserialize (map) json for state {}", state);
         } catch (JsonProcessingException e) {
-            log.error("Could not deserialize (process) json for state {}", state);
+            log.error("Failed to deserialize event {} — {}: {}",
+                    state.getUuid(), e.getClass().getSimpleName(), e.getMessage(), e);
         }
         return null;
     }

--- a/src/main/java/de/telekom/horizon/pulsar/service/EventMessageSupplier.java
+++ b/src/main/java/de/telekom/horizon/pulsar/service/EventMessageSupplier.java
@@ -28,6 +28,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.kafka.common.errors.CorruptRecordException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -43,7 +44,7 @@ import java.util.function.Supplier;
 
 /**
  * Supplier for providing {@link EventMessageContext} instances.
- *
+ * <p>
  * This class, annotated with {@code @Slf4j}, serves as a Supplier for generating instances
  * of {@link EventMessageContext}. It is designed to work in conjunction with a Pulsar
  * messaging system, KafkaPicker, and other components to fetch and process messages for a
@@ -74,7 +75,7 @@ public class EventMessageSupplier implements Supplier<EventMessageContext> {
      * @param subscriptionId     The subscriptionId for which messages are fetched.
      * @param factory            The {@link SseTaskFactory} used for obtaining related components.
      * @param includeHttpHeaders Boolean flag indicating whether to include HTTP headers in the generated {@code EventMessageContext}.
-     * @param startingOffset             Enables offset based streaming. Specifies the offset (message id) of the last received event message.
+     * @param startingOffset     Enables offset based streaming. Specifies the offset (message id) of the last received event message.
      * @param streamLimit        The {@link StreamLimit} represents any customer specific conditions for terminating the stream early.
      */
     public EventMessageSupplier(String subscriptionId, SseTaskFactory factory, boolean includeHttpHeaders, String startingOffset, StreamLimit streamLimit) {
@@ -92,7 +93,7 @@ public class EventMessageSupplier implements Supplier<EventMessageContext> {
 
     /**
      * Gets the next available {@code EventMessageContext} from the supplier.
-     *
+     * <p>
      * This method polls for message states, picks subscribed messages, and handles exceptions
      * accordingly. It also involves tracing spans and maintains a queue of message states for
      * efficient processing.
@@ -153,12 +154,24 @@ public class EventMessageSupplier implements Supplier<EventMessageContext> {
         var currentSpan = Optional.ofNullable(tracingHelper.getCurrentSpan());
         currentSpan.ifPresent(s -> s.error(e));
 
-        if (e.getCause() instanceof CouldNotFindEventMessageException || e instanceof SubscriberDoesNotMatchSubscriptionException) {
+        var cause = e.getCause();
+        if (
+                cause instanceof CouldNotFindEventMessageException ||
+                        e instanceof SubscriberDoesNotMatchSubscriptionException ||
+                        cause instanceof CorruptRecordException ||
+                        cause instanceof IllegalArgumentException
+        ) {
             try {
                 var status = Status.FAILED;
                 var statusMessage = new StatusMessage(state.getUuid(), state.getEvent().getId(), status, state.getDeliveryType());
-                eventWriter.send(Objects.requireNonNullElse(state.getEventRetentionTime(), EventRetentionTime.DEFAULT).getTopic(),statusMessage, tracingHelper);
-                currentSpan.ifPresent(s -> tracingHelper.addTagsToSpan(s, List.of(Pair.of("status", status.name()))));
+                statusMessage.withThrowable(Optional.ofNullable(e.getCause()).orElse(e));
+                eventWriter.send(Objects.requireNonNullElse(state.getEventRetentionTime(), EventRetentionTime.DEFAULT).getTopic(), statusMessage, tracingHelper);
+                currentSpan.ifPresent(s -> {
+                    tracingHelper.addTagsToSpan(s, List.of(
+                            Pair.of("status", status.name()),
+                            Pair.of("error", Optional.ofNullable(e.getCause()).orElse(e).getMessage())
+                    ));
+                });
             } catch (Exception e1) {
                 var err = String.format("Error occurred while updating the event status: %s", e1.getMessage());
                 log.error(err, e1);
@@ -170,7 +183,7 @@ public class EventMessageSupplier implements Supplier<EventMessageContext> {
 
     /**
      * Polls for message states and adds them to the queue.
-     *
+     * <p>
      * This method polls for message states and adds them to the queue. It also involves
      * tracing spans and maintains a queue of message states for efficient processing.
      */
@@ -223,10 +236,10 @@ public class EventMessageSupplier implements Supplier<EventMessageContext> {
 
     /**
      * Delays the current thread for the configured amount of time.
-     *
+     * <p>
      * This method delays the current thread for the configured amount of time.
      */
-    private void delay () {
+    private void delay() {
         var pollDelay = pulsarConfig.getSsePollDelay();
 
         if (lastPoll == null || pollDelay <= 0L) {

--- a/src/main/java/de/telekom/horizon/pulsar/service/SseService.java
+++ b/src/main/java/de/telekom/horizon/pulsar/service/SseService.java
@@ -99,6 +99,7 @@ public class SseService {
      * @return                    The {@link SseTaskStateContainer} representing the state of the emitted events.
      */
     public SseTaskStateContainer startEmittingEvents(String environment, String subscriptionId, String contentType, boolean includeHttpHeaders, String offset, StreamLimit streamLimit) {
+        log.info("Starting SSE stream for subscription {} in env {} (offset={})", subscriptionId, environment, offset);
         var responseContainer = new SseTaskStateContainer();
 
         taskExecutor.submit(sseTaskFactory.createNew(environment, subscriptionId, contentType, responseContainer, includeHttpHeaders, offset, streamLimit));

--- a/src/main/java/de/telekom/horizon/pulsar/service/SseTask.java
+++ b/src/main/java/de/telekom/horizon/pulsar/service/SseTask.java
@@ -26,6 +26,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.MDC;
 import org.springframework.http.MediaType;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
@@ -134,31 +135,38 @@ public class SseTask implements Runnable {
      */
     @Override
     public void run() {
-        var stream = createStreamTopology(eventMessageSupplier);
+        // MDC ensures subscriptionId appears in every log line from this thread (via LogstashEncoder)
+        // including Spring Data and driver-level logs, without needing explicit parameters.
+        MDC.put("subscriptionId", eventMessageSupplier.getSubscriptionId());
+        try {
+            if (sseTaskStateContainer.getCanceled().get()) {
+                return;
+            }
 
-        if (sseTaskStateContainer.getCanceled().get()) {
-            return;
-        }
+            var stream = createStreamTopology(eventMessageSupplier);
 
-        // Monitor the status of the emitter completion.
-        sseTaskStateContainer.getEmitter().onCompletion(() -> isEmitterCompleted.compareAndExchange(false, true));
-        sseTaskStateContainer.getEmitter().onError(e -> isEmitterCompleted.compareAndExchange(false, true));
+            // Monitor the status of the emitter completion.
+            sseTaskStateContainer.getEmitter().onCompletion(() -> isEmitterCompleted.compareAndExchange(false, true));
+            sseTaskStateContainer.getEmitter().onError(e -> isEmitterCompleted.compareAndExchange(false, true));
 
-        startTime = Instant.now();
+            startTime = Instant.now();
+            log.info("SSE stream started");
 
-        // Mark the task as running and increment the open connection gauge value.
-        sseTaskStateContainer.getRunning().compareAndExchange(false, true);
-        openConnectionGaugeValue.getAndSet(1);
+            // Mark the task as running and increment the open connection gauge value.
+            sseTaskStateContainer.getRunning().compareAndExchange(false, true);
+            openConnectionGaugeValue.getAndSet(1);
 
-        try (stream){
-            stream.forEach(this::emitEventMessage);
-        } catch (Exception e) {
-            log.error(String.format("Error occurred: %s", e.getMessage()), e);
-
-            sseTaskStateContainer.getEmitter().completeWithError(e);
+            try (stream) {
+                stream.forEach(this::emitEventMessage);
+            } catch (Exception e) {
+                log.error("SSE stream failed — {}: {}", e.getClass().getSimpleName(), e.getMessage(), e);
+                sseTaskStateContainer.getEmitter().completeWithError(e);
+            } finally {
+                openConnectionGaugeValue.getAndSet(0);
+                stopTime = Instant.now();
+            }
         } finally {
-            openConnectionGaugeValue.getAndSet(0);
-            stopTime = Instant.now();
+            MDC.remove("subscriptionId");
         }
     }
 
@@ -183,12 +191,14 @@ public class SseTask implements Runnable {
      */
     private boolean applyStreamEndFilter(EventMessageContext context) {
         if (isEmitterCompleted.get()) {
+            log.info("SSE stream ending — client disconnected");
             context.finishSpan();
 
             return false;
         }
 
         if (isCutOut.get()) {
+            log.info("SSE stream ending — connection cut out");
             sseTaskStateContainer.getEmitter().completeWithError(new ConnectionCutOutException());
             context.finishSpan();
 
@@ -202,6 +212,7 @@ public class SseTask implements Runnable {
             final boolean maxBytesExceeded = streamLimit.getMaxBytes() > 0 && bytesConsumed.get() >= streamLimit.getMaxBytes();
 
             if (maxNumberExceeded || maxMinutesExceeded || maxBytesExceeded) {
+                log.info("SSE stream ending — stream limit exceeded");
                 sseTaskStateContainer.getEmitter().completeWithError(new StreamLimitExceededException());
                 context.finishSpan();
                 return false;
@@ -226,6 +237,7 @@ public class SseTask implements Runnable {
 
         if (context.getSubscriptionEventMessage() == null) {
             if (lastEventMessage.plusMillis(pulsarConfig.getSseTimeout()).isBefore(now)) {
+                log.info("SSE stream ending — idle timeout ({}ms)", pulsarConfig.getSseTimeout());
                 sseTaskStateContainer.getEmitter().completeWithError(new ConnectionTimeoutException(String.format(TIMEOUT_MESSAGE, pulsarConfig.getSseTimeout())));
                 context.finishSpan();
 
@@ -326,14 +338,12 @@ public class SseTask implements Runnable {
 
             metricsHelper.getRegistry().counter(METRIC_SENT_SSE_EVENTS, metricsHelper.buildTagsFromSubscriptionEventMessage(msg)).increment();
         } catch (JsonProcessingException e) {
-            var err = String.format("Error occurred while emitting the event: %s", e.getMessage());
-            log.info(err, e);
+            log.warn("Failed to serialize event {} for delivery: {}", msg.getUuid(), e.getMessage(), e);
             sendSpan.error(e);
 
             pushMetadata(msg, Status.FAILED, e);
         } catch (Exception e) {
-            var err = String.format("Error occurred while emitting the event: %s", e.getMessage());
-            log.info(err, e);
+            log.warn("SSE emit failed, terminating — {}: {}", e.getClass().getSimpleName(), e.getMessage(), e);
             sendSpan.error(e);
 
             terminate();
@@ -373,8 +383,8 @@ public class SseTask implements Runnable {
                 afterSendFuture.thenAccept(result -> deDuplicationService.track(msg));
             }
         } catch (Exception e) {
-            var err = String.format("Error occurred while updating the event status: %s", e.getMessage());
-            log.error(err, e);
+            log.error("Failed to push status {} for event {} — {}: {}",
+                    status, msg.getUuid(), e.getClass().getSimpleName(), e.getMessage(), e);
             trackSpan.error(e);
         } finally {
             trackSpan.finish();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -55,6 +55,9 @@ pulsar:
     issuerUrls: ${PULSAR_ISSUER_URL:http://localhost:8080/auth/realms/default}
     oauth: ${PULSAR_SECURITY_OAUTH:true}
   defaultEnvironment: ${PULSAR_DEFAULT_ENVIRONMENT:integration}
+  mongo:
+    maxRetries: ${PULSAR_MONGO_MAX_RETRIES:1}
+    retryDelayMs: ${PULSAR_MONGO_RETRY_DELAY_MS:100}
 
 horizon:
   cache:

--- a/src/test/java/de/telekom/horizon/pulsar/service/EventMessageSupplierTest.java
+++ b/src/test/java/de/telekom/horizon/pulsar/service/EventMessageSupplierTest.java
@@ -33,6 +33,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -203,6 +204,78 @@ class EventMessageSupplierTest {
         assertEquals(states.getFirst().getUuid(), statusMessage.getUuid());
         assertEquals(states.getFirst().getEvent().getId(), statusMessage.getEvent().getId());
         assertEquals(Status.FAILED, statusMessage.getStatus());
+    }
+
+    @Test
+    void testPollMessageStatesRetriesOnMongoFailure() {
+        final var objectMapper = new ObjectMapper();
+
+        var states = MockHelper.createMessageStateMongoDocumentsForTesting(
+                MockHelper.pulsarConfig.getSseBatchSize(), MockHelper.TEST_ENVIRONMENT, Status.PROCESSED, false);
+
+        var callCount = new AtomicInteger(0);
+        when(MockHelper.messageStateMongoRepo.findByStatusInAndDeliveryTypeAndSubscriptionIdAsc(
+                eq(List.of(Status.PROCESSED)),
+                eq(DeliveryType.SERVER_SENT_EVENT),
+                eq(MockHelper.TEST_SUBSCRIPTION_ID),
+                any(Pageable.class)
+        )).thenAnswer(invocation -> {
+            if (callCount.getAndIncrement() == 0) {
+                throw new IllegalStateException("state should be: open");
+            }
+            return new SliceImpl<>(states);
+        });
+
+        var subscriptionEventMessage = MockHelper.createSubscriptionEventMessageForTesting(DeliveryType.SERVER_SENT_EVENT);
+        ConsumerRecord<String, String> record = Mockito.mock(ConsumerRecord.class);
+        try {
+            when(record.value()).thenReturn(objectMapper.writeValueAsString(subscriptionEventMessage));
+        } catch (JsonProcessingException e) {
+            fail(e);
+        }
+
+        when(MockHelper.kafkaTemplate.receive(
+                eq(MockHelper.TEST_TOPIC),
+                eq(states.getFirst().getCoordinates().partition()),
+                eq(states.getFirst().getCoordinates().offset()),
+                eq(Duration.ofMillis(30000))
+        )).thenReturn(record);
+
+        var eventWriterMock = mock(EventWriter.class);
+        ReflectionTestUtils.setField(eventMessageSupplier, "eventWriter", eventWriterMock, EventWriter.class);
+
+        var result = eventMessageSupplier.get();
+        assertNotNull(result);
+        assertNotNull(result.getSubscriptionEventMessage());
+
+        verify(MockHelper.messageStateMongoRepo, times(2))
+                .findByStatusInAndDeliveryTypeAndSubscriptionIdAsc(
+                        eq(List.of(Status.PROCESSED)),
+                        eq(DeliveryType.SERVER_SENT_EVENT),
+                        eq(MockHelper.TEST_SUBSCRIPTION_ID),
+                        any(Pageable.class));
+    }
+
+    @Test
+    void testPollMessageStatesThrowsAfterRetriesExhausted() {
+        when(MockHelper.messageStateMongoRepo.findByStatusInAndDeliveryTypeAndSubscriptionIdAsc(
+                eq(List.of(Status.PROCESSED)),
+                eq(DeliveryType.SERVER_SENT_EVENT),
+                eq(MockHelper.TEST_SUBSCRIPTION_ID),
+                any(Pageable.class)
+        )).thenThrow(new IllegalStateException("state should be: open"));
+
+        var eventWriterMock = mock(EventWriter.class);
+        ReflectionTestUtils.setField(eventMessageSupplier, "eventWriter", eventWriterMock, EventWriter.class);
+
+        assertThrows(IllegalStateException.class, () -> eventMessageSupplier.get());
+
+        verify(MockHelper.messageStateMongoRepo, times(2))
+                .findByStatusInAndDeliveryTypeAndSubscriptionIdAsc(
+                        eq(List.of(Status.PROCESSED)),
+                        eq(DeliveryType.SERVER_SENT_EVENT),
+                        eq(MockHelper.TEST_SUBSCRIPTION_ID),
+                        any(Pageable.class));
     }
 
     @Test

--- a/src/test/java/de/telekom/horizon/pulsar/service/SseTaskTest.java
+++ b/src/test/java/de/telekom/horizon/pulsar/service/SseTaskTest.java
@@ -31,6 +31,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.MDC;
 import org.springframework.kafka.support.SendResult;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyEmitter;
@@ -488,5 +489,30 @@ class SseTaskTest {
         verify(MockHelper.openConnectionGaugeValue, times(1)).getAndSet(0);
         // Verify that for each emitted event a de-duplication entry will be written
         verify(MockHelper.deDuplicationService, times(itemQueueInitialSize)).track(any());
+    }
+
+    @Test
+    void testMdcSubscriptionIdSetDuringExecution() {
+        when(sseTaskStateContainerMock.getCanceled()).thenReturn(new AtomicBoolean(false));
+        when(sseTaskStateContainerMock.getRunning()).thenReturn(new AtomicBoolean(false));
+
+        var emitterMock = mock(ResponseBodyEmitter.class);
+        when(sseTaskStateContainerMock.getEmitter()).thenReturn(emitterMock);
+
+        when(eventMessageSupplierMock.getSubscriptionId()).thenReturn(MockHelper.TEST_SUBSCRIPTION_ID);
+
+        var mdcCaptured = new AtomicBoolean(false);
+        when(eventMessageSupplierMock.get()).thenAnswer(i -> {
+            assertEquals(MockHelper.TEST_SUBSCRIPTION_ID, MDC.get("subscriptionId"));
+            mdcCaptured.set(true);
+            return new EventMessageContext();
+        });
+
+        when(MockHelper.pulsarConfig.getSseTimeout()).thenReturn(100L);
+
+        sseTaskSpy.run();
+
+        assertTrue(mdcCaptured.get(), "MDC subscriptionId should have been verified during execution");
+        assertNull(MDC.get("subscriptionId"), "MDC must be cleaned after run()");
     }
 }

--- a/src/test/java/de/telekom/horizon/pulsar/testutils/MockHelper.java
+++ b/src/test/java/de/telekom/horizon/pulsar/testutils/MockHelper.java
@@ -92,6 +92,8 @@ public class MockHelper {
         lenient().when(pulsarConfig.getSsePollDelay()).thenReturn(1000L);
         lenient().when(pulsarConfig.getThreadPoolSize()).thenReturn(100);
         lenient().when(pulsarConfig.getQueueCapacity()).thenReturn(100);
+        lenient().when(pulsarConfig.getMongoMaxRetries()).thenReturn(1);
+        lenient().when(pulsarConfig.getMongoRetryDelayMs()).thenReturn(1L);
 
         kafkaPicker = new KafkaPicker(kafkaTemplate);
         sseTaskFactory = new SseTaskFactory(pulsarConfig, connectionCache, connectionGaugeCache, eventWriter, kafkaPicker, messageStateMongoRepo, deDuplicationService, metricsHelper, tracingHelper);


### PR DESCRIPTION
## Problem

Pulsar SSE streams die with 500 errors when MongoDB Atlas PrivateLink connections drop. The MongoDB Java Driver 4.11.1 throws `IllegalStateException: state should be: open` when an in-flight query races with connection pool invalidation during a network blip. This kills the customer's SSE connection permanently — they must reconnect.

Additionally:
- Error logs contain no subscriptionId, making incident debugging in Loki nearly impossible
- The driver version (4.11.1) is below the minimum supported version for MongoDB 8.0 (requires 5.2+)
- Log levels are wrong (real failures at INFO, expected failures at ERROR)

## Fix

### MongoDB Driver Upgrade
Spring Boot 3.2.3 → 3.4.2, which brings MongoDB driver 4.11.1 → 5.2.1. Driver 5.x has:
- Dirty session fix (JAVA-5476) — sessions marked dirty on network errors, preventing corrupted reuse
- Better retry routing — avoids retrying against broken mongos instances
- Formal compatibility with MongoDB 8.0

The spring-parent team already validated this upgrade (only `mongo-java-server` test dep bump needed). Pulsar uses no removed driver APIs.

### Retry on MongoDB Poll Failures
`EventMessageSupplier.pollMessageStates()` now retries once (configurable) with jitter on any exception. The `IllegalStateException` is transient — the pool hands out a working connection within milliseconds. Without the retry, a single blip kills the stream. With it, the stream survives transparently.

Jitter (50-100ms randomized) prevents thundering herd when all SSE threads fail simultaneously during a PrivateLink drop.

### Structured Logging with MDC
`subscriptionId` is placed into MDC at the start of each SSE thread. LogstashEncoder automatically includes it in every JSON log line — including Spring Data and driver-level logs. No more "which subscription was this error for?"

### Stream Lifecycle Logging
Every stream now logs: when it starts, why it ended (idle timeout, client disconnect, stream limit, connection cut out), and at what log level (INFO for lifecycle, WARN for degraded, ERROR for unexpected).

### Other Fixes
- `sendEvent` errors promoted from INFO to WARN
- `handleException` differentiates expected failures (WARN) from unexpected (ERROR)
- Deserialization errors now include the exception and stack trace (previously lost)
- `/error` endpoint permitted to prevent `AccessDeniedException` log spam
- Stream resource leak on early cancellation fixed (pre-existing)

## Configuration

New configurable properties (with defaults):
```yaml
pulsar:
  mongo:
    maxRetries: ${PULSAR_MONGO_MAX_RETRIES:1}      # retries after initial failure
    retryDelayMs: ${PULSAR_MONGO_RETRY_DELAY_MS:100}  # base delay (actual: 50-100ms with jitter)
```

### Deployment Requirement
Append connection pool resilience parameters to the MongoDB connection string (`PULSAR_MONGO_URL`):
```
?minPoolSize=5&maxIdleTimeMS=60000&maxLifeTimeMS=300000&socketTimeoutMS=30000&serverSelectionTimeoutMS=30000
```
This ensures stale connections are evicted (PrivateLink drops produce no TCP RST — without `maxIdleTimeMS`, dead connections linger until TCP keepalive at 2 hours).

## Test Plan

- [x] All existing tests pass (Spring Boot 3.4.2 + driver 5.2.1)
- [x] New test: retry succeeds after transient `IllegalStateException`
- [x] New test: exception propagates after retries exhausted
- [x] New test: MDC contains subscriptionId during execution, cleaned up after
- [ ] Deploy to integration, verify in Loki:
  - SSE error logs include `subscriptionId` field
  - Stream start/end lifecycle visible
  - No `AccessDeniedException` spam
- [ ] Verify MongoDB connection pool metrics after Atlas failover test
- [ ] Verify OIDC token validation works with Spring Security 6.3